### PR TITLE
Add home page with project cards + SEO component (#35, #36)

### DIFF
--- a/__tests__/projects.test.ts
+++ b/__tests__/projects.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sortProjectsByTitle, type Project } from '../utils/projects';
+
+const make = (title: string): Project => ({
+    id: title.toLowerCase(),
+    title,
+    description: '',
+    githubLink: '',
+    technology: '',
+});
+
+describe('sortProjectsByTitle', () => {
+    it('sorts titles alphabetically, case-insensitively', () => {
+        const sorted = sortProjectsByTitle([make('Viron'), make('apex'), make('Roam')]);
+        expect(sorted.map((p) => p.title)).toEqual(['apex', 'Roam', 'Viron']);
+    });
+
+    it('does not mutate the input array', () => {
+        const input = [make('Beta'), make('Alpha')];
+        const snapshot = input.map((p) => p.title);
+        sortProjectsByTitle(input);
+        expect(input.map((p) => p.title)).toEqual(snapshot);
+    });
+
+    it('returns an empty array unchanged', () => {
+        expect(sortProjectsByTitle([])).toEqual([]);
+    });
+});

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import {Box, Button, Typography, Paper, Grid, Stack} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import CodeIcon from '@mui/icons-material/Code';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+import {
+    blurbBoxStyle,
+    blurbTitleStyle,
+    blurbGridContainerStyle,
+    infoCardStyle,
+    infoCardIconStyle,
+    infoCardTitleStyle,
+    infoCardIconSizeStyle
+} from '../styles/styles';
+
+const ORG_URL = 'https://github.com/Preponderous-Software';
+
+const InfoCard: React.FC<{
+    icon: React.ReactNode;
+    title: string;
+    content: string;
+    href?: string
+}> = ({icon, title, content, href}) => (
+    <Grid item xs={12} md={4}>
+        <Paper
+            elevation={0}
+            // When the card links somewhere, expose it as a focusable, keyboard-
+            // operable control: a mouse-only onClick left keyboard and screen-
+            // reader users unable to reach or activate these cards.
+            role={href ? 'link' : undefined}
+            tabIndex={href ? 0 : undefined}
+            sx={(theme) => ({
+                ...infoCardStyle(theme),
+                cursor: href ? 'pointer' : 'default',
+                '&:hover': href ? {
+                    transform: 'translateY(-2px)',
+                    boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+                    transition: 'transform 0.2s ease, box-shadow 0.2s ease'
+                } : {}
+            })}
+            onClick={() => href && window.open(href, '_blank', 'noopener,noreferrer')}
+            onKeyDown={(e) => {
+                if (href && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault();
+                    window.open(href, '_blank', 'noopener,noreferrer');
+                }
+            }}
+        >
+            <Box sx={(theme) => infoCardIconStyle(theme)}>
+                {icon}
+            </Box>
+            <Typography variant="h6" gutterBottom sx={(theme) => infoCardTitleStyle()}>
+                {title}
+            </Typography>
+            <Typography variant="body1" color="text.secondary">{content}</Typography>
+        </Paper>
+    </Grid>
+);
+
+const Blurb: React.FC = () => (
+    <Box sx={(theme) => blurbBoxStyle(theme)}>
+        <Box sx={{textAlign: 'center', py: {xs: 4, md: 8}}}>
+            <Typography
+                variant="h2"
+                component="h1"
+                gutterBottom
+                sx={(theme) => ({...blurbTitleStyle(theme), marginBottom: theme.spacing(2)})}
+            >
+                Preponderous Software
+            </Typography>
+            <Typography
+                variant="h6"
+                color="text.secondary"
+                sx={{maxWidth: 640, mx: 'auto', fontWeight: 400}}
+            >
+                Free and open-source games and assets — built in the open,
+                and easy to run, extend, and contribute to.
+            </Typography>
+            <Stack
+                direction={{xs: 'column', sm: 'row'}}
+                spacing={2}
+                justifyContent="center"
+                sx={{mt: 4}}
+            >
+                <Button variant="contained" size="large" href="#projects">
+                    Browse Projects
+                </Button>
+                <Button
+                    variant="outlined"
+                    size="large"
+                    href={ORG_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    endIcon={<OpenInNewIcon fontSize="small"/>}
+                >
+                    View on GitHub
+                </Button>
+            </Stack>
+        </Box>
+
+        <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{display: 'block', textAlign: 'center', letterSpacing: '0.1em'}}
+        >
+            Get involved
+        </Typography>
+
+        <Grid container spacing={4} sx={(theme) => blurbGridContainerStyle(theme)}>
+            <InfoCard
+                icon={<GitHubIcon sx={infoCardIconSizeStyle}/>}
+                title="Contribute"
+                content="Join our open-source community on GitHub. Each project welcomes issues and pull requests."
+                href={ORG_URL}
+            />
+            <InfoCard
+                icon={<CodeIcon sx={infoCardIconSizeStyle}/>}
+                title="Explore the Code"
+                content="Browse the source for our games, simulations, and libraries across many languages."
+                href={ORG_URL}
+            />
+            <InfoCard
+                icon={<FavoriteIcon sx={infoCardIconSizeStyle}/>}
+                title="Free & Open Source"
+                content="Everything we make is free to use, modify, and self-host for non-commercial purposes."
+            />
+        </Grid>
+    </Box>
+);
+
+export default Blurb;

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, Typography} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import CodeIcon from '@mui/icons-material/Code';
+import {
+    projectCardStyle,
+    projectCardContentStyle,
+    projectCardActionsStyle,
+} from '../styles/styles';
+
+interface ProjectCardProps {
+    title: string;
+    description: string;
+    githubLink: string;
+    technology: string;
+}
+
+// A small, fixed palette of muted brand-ish colours. Each project gets a stable
+// colour derived from its title so cards have a bit of visual identity without
+// being random on every render.
+const AVATAR_COLORS = ['#4263eb', '#7048e8', '#1098ad', '#f59f00', '#e8590c', '#0ca678'];
+
+const colorForTitle = (title: string): string => {
+    let hash = 0;
+    for (let i = 0; i < title.length; i++) {
+        hash = (hash * 31 + title.charCodeAt(i)) >>> 0;
+    }
+    return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+};
+
+const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink, technology}) => {
+    return (
+        <Card sx={projectCardStyle}>
+            <CardContent sx={projectCardContentStyle}>
+                <Stack direction="row" spacing={1.5} alignItems="center" sx={{mb: 1.5}}>
+                    <Avatar
+                        variant="rounded"
+                        aria-hidden
+                        sx={{
+                            bgcolor: colorForTitle(title),
+                            width: 40,
+                            height: 40,
+                            fontFamily: '"Space Grotesk", sans-serif',
+                            fontWeight: 700,
+                        }}
+                    >
+                        {title.charAt(0).toUpperCase()}
+                    </Avatar>
+                    <Typography variant="h6" component="div" sx={{fontWeight: 600, lineHeight: 1.2}}>
+                        {title}
+                    </Typography>
+                </Stack>
+                <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                        // Clamp to keep every card the same height regardless of
+                        // how long the project's description is.
+                        display: '-webkit-box',
+                        WebkitLineClamp: 3,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                    }}
+                >
+                    {description}
+                </Typography>
+            </CardContent>
+
+            {technology ? (
+                <Box sx={{px: 2, pb: 1}}>
+                    <Chip
+                        size="small"
+                        variant="outlined"
+                        icon={<CodeIcon/>}
+                        label={technology}
+                    />
+                </Box>
+            ) : null}
+
+            <CardActions sx={projectCardActionsStyle}>
+                <Box sx={{flexGrow: 1}}/>
+                <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<GitHubIcon/>}
+                    component={Link}
+                    href={githubLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    GitHub
+                </Button>
+            </CardActions>
+        </Card>
+    );
+};
+
+export default ProjectCard;

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,0 +1,36 @@
+import Head from 'next/head';
+import React from 'react';
+
+// Shared per-page document metadata: title, description, and Open Graph /
+// Twitter card tags so browser tabs, search engines, and shared links (Discord,
+// social) all show meaningful information. Render once near the top of each page.
+const SITE_NAME = 'Preponderous Software';
+const DEFAULT_DESCRIPTION =
+    'Free and open-source games and assets — built in the open and free to use.';
+
+interface SeoProps {
+    // Page-specific title; the site name is appended automatically. Omit on the
+    // home page to use the site name alone.
+    title?: string;
+    description?: string;
+}
+
+const Seo: React.FC<SeoProps> = ({title, description}) => {
+    const fullTitle = title ? `${title} — ${SITE_NAME}` : SITE_NAME;
+    const desc = description ?? DEFAULT_DESCRIPTION;
+    return (
+        <Head>
+            <title>{fullTitle}</title>
+            <meta name="description" content={desc}/>
+            <meta property="og:title" content={fullTitle}/>
+            <meta property="og:description" content={desc}/>
+            <meta property="og:type" content="website"/>
+            <meta property="og:site_name" content={SITE_NAME}/>
+            <meta name="twitter:card" content="summary"/>
+            <meta name="twitter:title" content={fullTitle}/>
+            <meta name="twitter:description" content={desc}/>
+        </Head>
+    );
+};
+
+export default Seo;

--- a/pages/data/projects.json
+++ b/pages/data/projects.json
@@ -1,0 +1,67 @@
+{
+  "projects": [
+    {
+      "id": "apex-ecosystem-simulator",
+      "title": "Apex-Ecosystem-Simulator",
+      "description": "Observe the activity of a virtual environment containing entities that depend on each other as sources of energy.",
+      "githubLink": "https://github.com/Preponderous-Software/Apex-Ecosystem-Simulator",
+      "technology": "Python"
+    },
+    {
+      "id": "beyond-nations",
+      "title": "Beyond-Nations",
+      "description": "Sandbox Nation Simulation RPG",
+      "githubLink": "https://github.com/Preponderous-Software/Beyond-Nations",
+      "technology": "C#"
+    },
+    {
+      "id": "env-lib-cpp",
+      "title": "env-lib-cpp",
+      "description": "Provides base classes for creating two-dimensional virtual worlds.",
+      "githubLink": "https://github.com/Preponderous-Software/env-lib-cpp",
+      "technology": "C++"
+    },
+    {
+      "id": "microbiome",
+      "title": "microbiome",
+      "description": "Witness the activity of a virtual microbial community.",
+      "githubLink": "https://github.com/Preponderous-Software/microbiome",
+      "technology": "C++"
+    },
+    {
+      "id": "ophidian",
+      "title": "Ophidian",
+      "description": "Control an ever-increasingly growing ophidian in a virtual environment.",
+      "githubLink": "https://github.com/Preponderous-Software/Ophidian",
+      "technology": "Python"
+    },
+    {
+      "id": "patchwork",
+      "title": "Patchwork",
+      "description": "Patchwork is a lightweight tool for visualizing 2D environments, built with Python.",
+      "githubLink": "https://github.com/Preponderous-Software/Patchwork",
+      "technology": "Python"
+    },
+    {
+      "id": "py-env-lib",
+      "title": "py_env_lib",
+      "description": "Provides base classes for creating two-dimensional virtual worlds.",
+      "githubLink": "https://github.com/Preponderous-Software/py_env_lib",
+      "technology": "Python"
+    },
+    {
+      "id": "roam",
+      "title": "Roam",
+      "description": "Explore a procedurally-generated 2D world and interact with your surroundings.",
+      "githubLink": "https://github.com/Preponderous-Software/Roam",
+      "technology": "Python"
+    },
+    {
+      "id": "viron",
+      "title": "Viron",
+      "description": "Viron is a flexible simulation framework for building and managing 2D virtual environments.",
+      "githubLink": "https://github.com/Preponderous-Software/Viron",
+      "technology": "Java"
+    }
+  ]
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,37 +1,65 @@
 import type {NextPage} from 'next'
-import Head from 'next/head'
-import {Box, Container, Typography} from '@mui/material'
+import {Box, Container, Grid, Typography} from '@mui/material'
+import React from 'react'
 import TopBar from '../components/TopBar'
 import BottomBar from '../components/BottomBar'
+import Seo from '../components/Seo'
+import Blurb from '../components/Blurb'
+import ProjectCard from '../components/ProjectCard'
+import {sortProjectsByTitle, type Project} from '../utils/projects'
+import {
+    pageStyle,
+    sectionHeaderStyle,
+    sectionDividerStyle,
+    projectsBoxStyle,
+    gridContainerStyle,
+    gridItemStyle,
+} from '../styles/styles'
+
+interface ProjectData {
+    projects: Project[];
+}
+
+const projectData = require('./data/projects.json') as ProjectData
 
 // pull the displayed version from package.json so the footer stays in sync
 const version = require('../package.json').version
 
-// Scaffold home page with shared chrome (TopBar/BottomBar + color-mode toggle).
-// The full project showcase — blurb + cards — lands with the home-page sub-issue;
-// the dedicated SEO component replaces the inline <Head> in its own sub-issue.
+const SectionDivider: React.FC = () => (
+    <Box sx={(theme) => sectionDividerStyle(theme)}/>
+)
+
+const ProjectsSection: React.FC<{projects: Project[]}> = ({projects}) => (
+    <Box id="projects" sx={projectsBoxStyle}>
+        <Typography variant="h3" component="div" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            Projects
+        </Typography>
+        <Grid container {...gridContainerStyle}>
+            {projects.map((project) => (
+                <Grid item {...gridItemStyle} key={project.id}>
+                    <ProjectCard
+                        title={project.title}
+                        description={project.description}
+                        githubLink={project.githubLink}
+                        technology={project.technology}
+                    />
+                </Grid>
+            ))}
+        </Grid>
+    </Box>
+)
+
 const Home: NextPage = () => {
+    const projects = sortProjectsByTitle(projectData.projects)
     return (
-        <Box sx={{display: 'flex', flexDirection: 'column', minHeight: '100vh'}}>
-            <Head>
-                <title>Preponderous Software</title>
-                <meta name="description" content="Free and open-source games and assets by Preponderous Software."/>
-            </Head>
+        <Box sx={(theme) => pageStyle(theme)}>
+            <Seo/>
             <TopBar/>
-            <Box component="main" id="main" sx={{flexGrow: 1}}>
-                <Container maxWidth="md" sx={{py: 8}}>
-                    <Typography variant="h1" sx={{fontSize: {xs: '2.5rem', md: '3.5rem'}, mb: 2}}>
-                        Preponderous Software
-                    </Typography>
-                    <Typography variant="h5" color="text.secondary">
-                        Developing free and open-source games and assets.
-                    </Typography>
-                    <Typography variant="body1" sx={{mt: 4}} color="text.secondary">
-                        This site is being rebuilt with Next.js. The redesigned home page,
-                        project showcase, and navigation are on their way.
-                    </Typography>
-                </Container>
-            </Box>
+            <Container component="main" id="main" maxWidth="xl" sx={{py: 4, flexGrow: 1}}>
+                <Blurb/>
+                <SectionDivider/>
+                <ProjectsSection projects={projects}/>
+            </Container>
             <BottomBar version={version}/>
         </Box>
     )

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -114,3 +114,160 @@ export const flexContainerStyle = (theme: Theme, options?: {
     gap: theme.spacing(options?.gap || 2),
     flexWrap: options?.flexWrap || 'wrap',
 });
+
+/**
+ * Main page layout: a clean themed background that fills the viewport.
+ */
+export const pageStyle = (theme: Theme) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
+    backgroundColor: theme.palette.background.default,
+});
+
+/**
+ * Section heading: text in the standard colour with a short primary accent bar.
+ */
+export const sectionHeaderStyle = (theme: Theme) => ({
+    fontWeight: 700,
+    letterSpacing: '-0.01em',
+    display: 'inline-block',
+    marginBottom: theme.spacing(3),
+    '&::after': {
+        content: '""',
+        display: 'block',
+        width: '44px',
+        height: '3px',
+        marginTop: theme.spacing(1),
+        borderRadius: '2px',
+        backgroundColor: theme.palette.primary.main,
+    },
+});
+
+/**
+ * Clean hairline divider between sections.
+ */
+export const sectionDividerStyle = (theme: Theme) => ({
+    height: '1px',
+    border: 0,
+    backgroundColor: theme.palette.divider,
+    marginY: theme.spacing(6),
+});
+
+/**
+ * Hover lift applied to each card in the project grid.
+ */
+export const cardWrapperStyle = {
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+    },
+};
+
+/**
+ * Responsive grid container spacing for the project grid.
+ */
+export const gridContainerStyle = {spacing: {xs: 2, md: 3}, pb: 4};
+
+/**
+ * Responsive grid item breakpoints — capped at 4 columns (lg) for readability.
+ */
+export const gridItemStyle = {
+    xs: 12, sm: 6, md: 4, lg: 3,
+    sx: cardWrapperStyle,
+};
+
+/**
+ * Projects section container layout.
+ */
+export const projectsBoxStyle = {flexGrow: 1, marginBottom: 2};
+
+/**
+ * Project card with a fixed height so the grid stays even.
+ */
+export const projectCardStyle = {
+    height: '16rem',
+    display: 'flex',
+    flexDirection: 'column',
+};
+
+/**
+ * Content area of a project card.
+ */
+export const projectCardContentStyle = {
+    flexGrow: 1,
+};
+
+/**
+ * Action area of a project card.
+ */
+export const projectCardActionsStyle = {
+    flexGrow: 0,
+    paddingX: 2,
+    paddingBottom: 2,
+};
+
+/**
+ * Blurb (hero) section container.
+ */
+export const blurbBoxStyle = (theme: Theme) => ({
+    flexGrow: 1,
+    paddingY: theme.spacing(4),
+});
+
+/**
+ * Centered blurb title.
+ */
+export const blurbTitleStyle = (theme: Theme) => ({
+    fontWeight: 700,
+    letterSpacing: '-0.02em',
+    marginBottom: theme.spacing(4),
+    textAlign: 'center',
+});
+
+/**
+ * Spacing above the blurb info-card grid.
+ */
+export const blurbGridContainerStyle = (theme: Theme) => ({
+    marginTop: theme.spacing(2),
+});
+
+/**
+ * Info card: centered content with a hover lift.
+ */
+export const infoCardStyle = (theme: Theme) => ({
+    padding: theme.spacing(3),
+    height: '100%',
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    '&:hover': {
+        transform: 'translateY(-2px)',
+        boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
+    },
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
+});
+
+/**
+ * Icon wrapper for info cards.
+ */
+export const infoCardIconStyle = (theme: Theme) => ({
+    marginBottom: theme.spacing(2),
+    color: theme.palette.primary.main,
+});
+
+/**
+ * Bold title for info cards.
+ */
+export const infoCardTitleStyle = () => ({
+    fontWeight: 'bold',
+});
+
+/**
+ * Standard icon size for info cards.
+ */
+export const infoCardIconSizeStyle = {
+    fontSize: 40,
+};

--- a/utils/projects.ts
+++ b/utils/projects.ts
@@ -1,0 +1,16 @@
+// A showcased project, as stored in pages/data/projects.json (seeded from the
+// legacy application.yaml). Kept framework-free so the sort/filter helpers below
+// stay pure and unit-testable.
+export interface Project {
+    id: string;
+    title: string;
+    description: string;
+    githubLink: string;
+    technology: string;
+}
+
+// Sort projects alphabetically by title, case-insensitively. Returns a new
+// array (does not mutate the input) so callers can keep the source order.
+export const sortProjectsByTitle = (projects: Project[]): Project[] =>
+    [...projects].sort((a, b) =>
+        a.title.toLowerCase().localeCompare(b.title.toLowerCase()));


### PR DESCRIPTION
## Summary

The real home page plus its SEO component — two complementary #31 sub-issues (the home page consumes `Seo`). Builds on the #32 scaffold and the #33/#34 chrome, mirroring [`dansplugins-dot-com`](https://github.com/Dans-Plugins/dansplugins-dot-com) minus the community features #31 puts out of scope.

**#36 — SEO**
- `components/Seo.tsx` — shared `<Head>`: title (site name appended), description, Open Graph + Twitter card tags. Site defaults for Preponderous.

**#35 — Home page**
- `components/ProjectCard.tsx` — avatar (stable colour hashed from title), title, 3-line-clamped description, **technology** chip, GitHub button.
- `components/Blurb.tsx` — hero (title, subtitle, *Browse Projects* + *View on GitHub*) and three "get involved" info cards.
- `pages/data/projects.json` — **seeded verbatim from `src/main/resources/application.yaml`** (title / description / githubLink / technology).
- `utils/projects.ts` + `__tests__/projects.test.ts` — pure `sortProjectsByTitle` + 3 tests.
- `styles/styles.ts` — page/section/grid/card/blurb/info-card helpers.
- `pages/index.tsx` — `Seo` + chrome + `Blurb` + divider + alphabetised project-card grid (`#projects` anchor for the hero button).

## Mirror-not-invent / deliberate deviations
- Dropped from `PluginCard`: `LikeButton`, guide link, SpigotMC button, bStats server-count chip (replaced with a **technology** chip). Dropped from the page: visit counter, like counts, popularity/most-liked sort. All are community/dynamic features out of scope per #31.
- **Data omission:** the `preponderous-website` entry in `application.yaml` is left out — its `github-link` points at a differently-named repo (`preponderous-website` vs this `preponderous-dot-org`) and listing the site on its own showcase is redundant. 9 of 10 entries carried over verbatim; nothing invented.

## Test plan
- [x] `npm run build` — compiled, types valid, lint clean, 3 pages (home 28.4 kB)
- [x] `npm test` — vitest, **10 passing** (projects 3 + nav 3 + colorMode 4)
- [x] Node 18.5.0 / npm 9.6.2

## Scope note
~492 source net LOC, over the ~400 soft ceiling (under the ~800 hard); 8 files. This is the dependency-coupled exception — the home page can't ship without `Seo` + `Blurb` + `ProjectCard` + their styles, and shipping any of those without the page would leave unused components.

Part of #31.
Closes #35.
Closes #36.

drafted by Claude on behalf of Daniel Stephenson