### PR TITLE
Add friendly 404 and 500 error pages (#37)

### DIFF
--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {Box, Button, Container, Typography} from '@mui/material';
+import HomeIcon from '@mui/icons-material/Home';
+import TopBar from './TopBar';
+import Seo from './Seo';
+import BottomBar from './BottomBar';
+import {pageStyle, sectionHeaderStyle} from '../styles/styles';
+
+const version = require('../package.json').version;
+
+/**
+ * Shared layout for the site's error pages (404 / 500). Renders the standard
+ * page chrome (TopBar/BottomBar) around a centred message and a link home, so a
+ * thrown or missing route still looks like the rest of the MUI-themed site
+ * instead of Next.js's unstyled default.
+ */
+const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({code, title, message}) => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo title={`${code} — ${title}`} description={message}/>
+        <TopBar/>
+        <Container component="main" id="main" maxWidth="sm" sx={{py: 8, textAlign: 'center', flexGrow: 1}}>
+            <Typography variant="h1" color="primary" sx={{fontWeight: 700}}>
+                {code}
+            </Typography>
+            <Typography variant="h4" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                {title}
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
+                {message}
+            </Typography>
+            <Button variant="contained" startIcon={<HomeIcon/>} href="/">
+                Back to home
+            </Button>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default ErrorPage;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,13 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const NotFoundPage: NextPage = () => (
+    <ErrorPage
+        code="404"
+        title="Page not found"
+        message="The page you're looking for doesn't exist or may have moved."
+    />
+);
+
+export default NotFoundPage;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,13 @@
+import type {NextPage} from 'next';
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const ServerErrorPage: NextPage = () => (
+    <ErrorPage
+        code="500"
+        title="Something went wrong"
+        message="An unexpected error occurred on our end. Please try again in a moment."
+    />
+);
+
+export default ServerErrorPage;


### PR DESCRIPTION
## Summary

Mirror [`dansplugins-dot-com`](https://github.com/Dans-Plugins/dansplugins-dot-com)'s error pages so a missing or thrown route stays within the MUI-themed site chrome instead of Next.js's unstyled default.

- `components/ErrorPage.tsx` — shared layout: `TopBar`/`BottomBar` around a centred code/title/message and a "Back to home" button; sets per-page SEO via the `Seo` component.
- `pages/404.tsx` — "Page not found".
- `pages/500.tsx` — "Something went wrong".

## Test plan
- [x] `npm run build` — compiled, types valid, lint clean; **`/404` and `/500` now emitted as static pages**
- [x] `npm test` — vitest, 10 passing (unchanged — error pages are presentational, no new logic; consistent with DPC, which has no test for these)
- [x] Node 18.5.0 / npm 9.6.2

## Notes
Reuses the existing chrome, `Seo`, and `pageStyle`/`sectionHeaderStyle` helpers — no new styles or dependencies. 3 files, 65 LOC.

Part of #31.
Closes #37.

drafted by Claude on behalf of Daniel Stephenson