### PR TITLE
Rewrite docs for the Next.js stack + add doc set (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+The site is being redesigned from Spring Boot + Thymeleaf to Next.js + React + MUI, mirroring [dansplugins-dot-com](https://github.com/Dans-Plugins/dansplugins-dot-com) (epic #31).
+
+### Added
+
+- Next.js + React + Material UI + Emotion project scaffold, alongside the existing app (#32).
+- Shared layout chrome: `TopBar` and `BottomBar`, with an accessible "skip to main content" link (#33).
+- Persisted light/dark color-mode toggle that follows the OS preference until the visitor chooses (#34).
+- Home page with a data-driven project showcase: `ProjectCard`, intro `Blurb`, and a grid seeded from `pages/data/projects.json` (#35).
+- `Seo` component emitting title, description, and Open Graph / Twitter card metadata (#36).
+- Friendly themed `404` and `500` error pages within the standard chrome (#37).
+- GitHub Actions CI: test + build on pull requests, with a Docker image build on `main` (#27).
+- Documentation set: `README`, `CONFIG.md`, `USER_GUIDE.md`, `CONTRIBUTING.md`, and this changelog (#39).
+
+### Planned
+
+- Component-render test coverage (#38) and a containerized build/deploy cutover that retires the legacy Spring Boot app (#40).

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,45 @@
+# Configuration Guide
+
+This document describes the configuration options for the Preponderous Software website.
+
+## Environment Variables
+
+The site is a static project showcase and currently requires **no environment variables** to build or run. If configurable values are added in the future, create a `.env.local` file in the project root (it is excluded from version control) and document the variables here.
+
+## Project Showcase Data
+
+The list of projects shown on the home page is data-driven, not hard-coded. It lives in:
+
+```
+pages/data/projects.json
+```
+
+The file contains a single `projects` array. Each entry supports these fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | Unique identifier for the project (used as the React key). Use a URL-safe slug. |
+| `title` | yes | Project name shown on the card. |
+| `description` | yes | Short description. Clamped to three lines on the card. |
+| `githubLink` | yes | URL to the project's source repository (opens in a new tab). |
+| `technology` | yes | Primary language/technology, shown as a chip (e.g. `Python`, `Java`, `C++`). |
+
+Projects are sorted alphabetically by title at render time (see `utils/projects.ts`), so entries may be listed in any order.
+
+**Example entry:**
+
+```json
+{
+  "id": "viron",
+  "title": "Viron",
+  "description": "Viron is a flexible simulation framework for building and managing 2D virtual environments.",
+  "githubLink": "https://github.com/Preponderous-Software/Viron",
+  "technology": "Java"
+}
+```
+
+To add, remove, or edit a showcased project, change this file — no code changes are required.
+
+## next.config.js
+
+Additional Next.js configuration lives in `next.config.js` in the project root. Refer to the [Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/introduction) for all available options.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Thank You
+
+Thank you for your interest in contributing to the Preponderous Software website! This guide will help you get started.
+
+## Links
+
+- [GitHub Organization](https://github.com/Preponderous-Software)
+- [Repository](https://github.com/Preponderous-Software/preponderous-dot-org)
+
+## Requirements
+
+- A GitHub account
+- Git installed on your local machine
+- [Node.js](https://nodejs.org/en/) (v18 or later, to match CI)
+- A code editor (e.g. VS Code)
+- A basic understanding of TypeScript and React
+
+## Getting Started
+
+1. [Sign up for GitHub](https://github.com/signup) if you don't have an account.
+2. Fork the repository by clicking **Fork** at the top right of the repo page.
+3. Clone your fork: `git clone https://github.com/<your-username>/preponderous-dot-org.git`
+4. Open the project in your editor.
+5. Install dependencies: `npm install`
+6. Start the development server: `npm run dev`
+   If you encounter errors, please open an issue.
+
+## Identifying What to Work On
+
+Work items are tracked as [GitHub issues](https://github.com/Preponderous-Software/preponderous-dot-org/issues).
+
+## Making Changes
+
+1. Make sure an issue exists for the work. If not, create one.
+2. Create a branch: `git checkout -b <branch-name>`
+3. Make your changes.
+4. Test your changes (see [Testing](#testing)).
+5. Commit: `git commit -m "Description of changes"`
+6. Push: `git push origin <branch-name>`
+7. Open a pull request, linking the related issue with `Closes #<number>`.
+8. Address review feedback.
+
+## Testing
+
+Lint and run the unit tests before opening a pull request:
+
+```bash
+npm run lint
+npm test
+```
+
+For manual testing, start the development server:
+
+```bash
+npm run dev
+```
+
+## Questions
+
+Open an [issue](https://github.com/Preponderous-Software/preponderous-dot-org/issues) if you have a question.

--- a/README.md
+++ b/README.md
@@ -1,74 +1,97 @@
 # Preponderous Software Website
 
-This is a Spring Boot application for the Preponderous Software website, built with Java 21, Gradle, and Docker support.
+## Description
 
-## About Preponderous Software
+The Preponderous Software website is a [Next.js](https://nextjs.org/) web application that serves as the public face of Preponderous Software. It showcases the projects — free and open-source games, simulations, and libraries — and links out to their source on GitHub. Built with React and [Material UI](https://mui.com/), it mirrors the structure of the [Dan's Plugins Community website](https://github.com/Dans-Plugins/dansplugins-dot-com).
 
-At Preponderous Software, we develop free and open-source games and assets, focusing on projects like Beyond Nations and Viron. Through these initiatives, we aim to provide valuable resources to the developer community, fostering collaboration and innovation in open-source software development.
+## Installation
 
-## Key Projects
+### First Time Installation
 
-### Beyond Nations
-A sandbox nation simulation RPG that allows players to explore a procedurally generated world, collect resources, and interact with various entities.
+1. Ensure [Node.js](https://nodejs.org/en/) (v18 or later) is installed on your machine.
+2. Clone this repository: `git clone https://github.com/Preponderous-Software/preponderous-dot-org.git`
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Build the project:
+   ```bash
+   npm run build
+   ```
+5. Start the server:
+   ```bash
+   npm run start
+   ```
 
-### Viron
-A tool for creating and managing virtual environments and entities within those environments, intended for game development and other applications.
+The site will be available at `http://localhost:3000`.
 
-## Our Commitment to Open Source
-- Free and open-source software
-- Community-driven development
-- Innovative game development tools
-- Engaging sandbox experiences
+### Development Server
 
-## Prerequisites
-- Java Development Kit (JDK) 21
-- Docker and Docker Compose
-- Gradle (or use the included Gradle wrapper)
+For local development with hot-reloading:
 
-## Building the Project
-### Build with Gradle:
+```bash
+npm run dev
+```
 
-./gradlew build
+## Usage
 
-### Build with Docker:
-docker build -t preponderous-website .
+### Documentation
 
-## Running the Application
-### Run with Gradle:
-./gradlew bootRun
+- [User Guide](USER_GUIDE.md) – Getting started and common scenarios
+- [Configuration Guide](CONFIG.md) – Configuration and the project showcase data
+- [Contributing](CONTRIBUTING.md) – How to contribute
+- [Changelog](CHANGELOG.md) – Release history
 
-### Run with Docker:
-docker run -p 8080:8080 preponderous-website
+## Support
 
-### Run with Docker Compose:
-docker compose up
+### Experiencing a bug?
 
-#### Or in detached mode
-docker compose up -d
+Please file a bug report [here](https://github.com/Preponderous-Software/preponderous-dot-org/issues/new).
+
+- [Known Bugs](https://github.com/Preponderous-Software/preponderous-dot-org/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Testing
-Run the tests:
 
-./gradlew test
+### Lint
+
+```bash
+npm run lint
+```
+
+If you see no errors, the lint check has passed.
+
+### Unit Tests
+
+The site uses [Vitest](https://vitest.dev/) for unit tests. Run the suite with:
+
+```bash
+npm test
+```
+
+Test files live in the `__tests__/` directory. If all tests pass, the suite has succeeded.
 
 ## Technologies Used
-- Java 21
-- Spring Boot with Thymeleaf templating
-- HTMX for dynamic content loading
-- Bootstrap for responsive styling
-- Lombok for reducing boilerplate code
-- Docker for containerization
 
-## Access the Application
-After starting the application, access it at: http://localhost:8080
+- [Next.js](https://nextjs.org/) (React)
+- [Material UI](https://mui.com/) with [Emotion](https://emotion.sh/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Vitest](https://vitest.dev/) for unit testing
 
 ## 📄 License
 
-This project is licensed under the **Preponderous Non-Commercial License (Preponderous-NC)**.  
+This project is licensed under the **Preponderous Non-Commercial License (Preponderous-NC)**.
 It is free to use, modify, and self-host for **non-commercial** purposes, but **commercial use requires a separate license**.
 
-> **Disclaimer:** *Preponderous Software is not a legal entity.*  
+> **Disclaimer:** *Preponderous Software is not a legal entity.*
 > All rights to works published under this license are reserved by the copyright holder, **Daniel McCoy Stephenson**.
 
-Full license text:  
+Full license text:
 [https://github.com/Preponderous-Software/preponderous-nc-license/blob/main/LICENSE.md](https://github.com/Preponderous-Software/preponderous-nc-license/blob/main/LICENSE.md)
+
+## Project Status
+
+This project is in active development. It is being redesigned from its original Spring Boot + Thymeleaf implementation to the Next.js stack described above; containerized build and deploy are tracked in [#40](https://github.com/Preponderous-Software/preponderous-dot-org/issues/40).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,43 @@
+# User Guide
+
+This guide is for visitors to the Preponderous Software website.
+
+## Prerequisites
+
+No special software is required to use the website — just a modern web browser.
+
+## First Steps
+
+1. Open your web browser and navigate to the site.
+2. Read the introduction at the top of the home page.
+3. Browse the project cards to see the games, simulations, and libraries Preponderous Software develops.
+
+## Common Scenarios
+
+### Browsing the Projects
+
+1. Open the home page.
+2. Scroll to the **Projects** section, or click **Browse Projects** in the hero.
+3. Each card shows the project's name, a short description, and its primary technology.
+
+### Opening a Project's Source Code
+
+1. Find the project's card on the home page.
+2. Click the **GitHub** button on the card to open its repository in a new tab.
+
+You can also reach the full GitHub organization via the **GitHub** link in the top navigation bar or **View on GitHub** in the hero.
+
+### Switching Between Light and Dark Mode
+
+1. Use the sun/moon toggle in the top (or bottom) navigation bar.
+2. Your choice is remembered for future visits. If you've never chosen, the site follows your operating system's light/dark preference.
+
+### Reporting a Website Bug
+
+If you find a bug on the website itself:
+
+1. Go to the [GitHub Issues page](https://github.com/Preponderous-Software/preponderous-dot-org/issues).
+2. Click **New Issue**.
+3. Describe the problem and include steps to reproduce it.
+
+You can also use the **Report a Bug** link in the footer.


### PR DESCRIPTION
## Summary

Bring the documentation in line with the Next.js redesign, mirroring [`dansplugins-dot-com`](https://github.com/Dans-Plugins/dansplugins-dot-com)'s doc set. Per maintainer direction, the README is a **full npm-only rewrite** (the prior Spring Boot instructions are replaced).

- **README.md** — Node 18+ prerequisite; `npm install`/`build`/`start`/`dev`; lint + Vitest testing; updated "Technologies Used" (Next.js/React/MUI/TS/Vitest); keeps the **Preponderous-NC** license section. A "Project Status" note records the Spring Boot → Next.js redesign and that containerized deploy is tracked in #40.
- **CONFIG.md** — no env vars required; documents the project-showcase data file (`pages/data/projects.json`) and its fields, plus `next.config.js`.
- **USER_GUIDE.md** — visitor guide for the **actual** pages: browsing projects, opening source, the color-mode toggle, reporting a bug.
- **CONTRIBUTING.md** — Node 18+, fork/clone/`npm install`/`dev`, branch, lint+test, PR workflow against this repo.
- **CHANGELOG.md** — Keep a Changelog format; `[Unreleased]` records the redesign to date (#32–#37, CI #27, docs #39).

## Accuracy
Documented only what exists today — npm scripts (present in `package.json`), `projects.json` + `utils/projects.ts`, the chrome toggle, the footer bug link. **Deliberately omits** DPC-only surfaces (News/Guides/Leaderboard/Account, API env vars) and Docker/compose (those arrive with #40), so nothing references a not-yet-present file or command.

## Test plan
- [x] Docs-only change (5 `.md` files); npm anchor **UNVERIFIED-not-applicable** (no code/build files touched). Gradle CI still runs and passes (Java untouched).
- [x] All internal doc links and every referenced command/path confirmed to exist.

Part of #31.
Closes #39.

drafted by Claude on behalf of Daniel Stephenson