### PR TITLE
Containerize the Next.js app + switch CI to npm (#40, part 1/2)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18
+
+# Install basic development tools
+RUN apt update && apt install -y less man-db sudo
+
+# Ensure the default `node` user has access to `sudo`
+ARG USERNAME=node
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Set the `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+// See https://containers.dev/implementors/json_reference/ for configuration reference
+{
+	"name": "Preponderous Software Website",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "node",
+
+	// forward the Next.js dev/start port
+	"forwardPorts": [3000]
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+node_modules
+.next
+.git
+.github
+.devcontainer
+__tests__
+*.md
+Dockerfile
+.dockerignore
+# legacy Spring Boot artifacts (removed in a follow-up cutover PR)
+src
+build
+.gradle
+gradle
+gradlew
+gradlew.bat
+build.gradle
+settings.gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,53 +9,46 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
       with:
-        java-version: '21'
-        distribution: 'temurin'
-    
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    
-    - name: Make gradlew executable
-      run: chmod +x ./gradlew
-    
+        node-version: '18'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Lint
+      run: npm run lint
+
     - name: Run tests
-      run: ./gradlew test
-    
-    - name: Build application
-      run: ./gradlew build
+      run: npm test
+
+    - name: Build
+      run: npm run build
 
   docker:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main'
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    
+
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
@@ -65,7 +58,7 @@ jobs:
           type=ref,event=branch
           type=sha,prefix={{branch}}-
           type=raw,value=latest,enable={{is_default_branch}}
-    
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,24 @@
-
-# Build stage
-FROM eclipse-temurin:21-jdk AS build
+FROM node:18
 
 WORKDIR /app
 
-# Copy the Gradle wrapper, build.gradle and settings.gradle
-COPY gradlew .
-COPY gradle gradle
-COPY build.gradle .
-COPY settings.gradle .
+# Install dependencies (use the lockfile for reproducible builds)
+COPY package*.json ./
+RUN npm ci
 
-# Make the gradlew script executable
-RUN chmod +x ./gradlew
+# Bundle the Next.js app source
+COPY components ./components
+COPY pages ./pages
+COPY public ./public
+COPY styles ./styles
+COPY utils ./utils
+COPY next-env.d.ts ./
+COPY next.config.js ./
+COPY tsconfig.json ./
 
-# Copy the source code
-COPY src src
+# Build the production bundle
+RUN npm run build
 
-# Build the application
-RUN ./gradlew build --no-daemon -x test
+EXPOSE 3000
 
-# Runtime stage
-FROM eclipse-temurin:21-jre
-
-WORKDIR /app
-
-# Copy the built application from the build stage
-COPY --from=build /app/build/libs/*.jar app.jar
-
-# Environment variables for Spring Boot
-ENV SPRING_DEVTOOLS_RESTART_ENABLED=false
-ENV SPRING_DEVTOOLS_LIVERELOAD_ENABLED=false
-ENV SPRING_DOCKER_COMPOSE_ENABLED=false
-
-# Expose the port the app runs on
-EXPOSE 8080
-
-# Command to run the application
-CMD ["java", "-jar", "app.jar"]
+CMD [ "npm", "run", "start" ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,17 +1,7 @@
-version: '3.8'
-
 services:
-  app:
+  preponderous-website:
     build:
       context: .
-      dockerfile: Dockerfile
-    container_name: spring-htmx-app
     ports:
-      - "8080:8080"
-    environment:
-      - SPRING_PROFILES_ACTIVE=prod
+      - "3000:3000"
     restart: unless-stopped
-
-volumes:
-  gradle-cache:
-    name: gradle-cache


### PR DESCRIPTION
## Summary

First half of the #40 cutover: make the **Next.js app the built/deployed artifact** and move CI to npm, mirroring [`dansplugins-dot-com`](https://github.com/Dans-Plugins/dansplugins-dot-com). The legacy Spring Boot source stays in place here and is removed in **part 2/2** (so this PR is reversible and the diff stays reviewable).

- **Dockerfile** — Node 18 build (`npm ci` → copy Next.js source → `npm run build` → `npm run start`), `EXPOSE 3000`. Was the `eclipse-temurin` Gradle/Spring Boot image on 8080.
- **compose.yaml** — single `preponderous-website` service on 3000; dropped the Spring Boot service, gradle-cache volume, and the obsolete `version` key.
- **.dockerignore** — lean build context; excludes the still-present legacy Spring Boot/Gradle files from the image.
- **.devcontainer/** — Node 18 dev container forwarding 3000.
- **.github/workflows/ci.yml** — Gradle test/build job replaced with Node (`npm ci`, `npm run lint`, `npm test`, `npm run build`); the Docker build/push job (main only) now builds the Next.js image.

## Test plan
- [x] `npm ci` — lockfile in sync
- [x] `npm run lint` — no warnings/errors
- [x] `npm test` — vitest, 14 passing
- [x] `npm run build` — compiled, types valid, 3 pages
- [ ] **Docker image build — UNVERIFIED:** no Docker daemon in the dev environment, and the CI docker job runs only on `main` post-merge (not on PRs). The Dockerfile closely mirrors DPC's working one; its commands (`npm ci`/`build`/`start`) are verified above.

## Hold for human review
Touches `.github/workflows/ci.yml`, `Dockerfile`, and `compose.yaml` — all do-not-auto-merge paths — and **changes the deployed artifact** (Spring Boot → Next.js). Do not auto-merge; please review the deploy implications. After this, **part 2/2** removes the legacy Spring Boot app.

Part of #31 and #40.

drafted by Claude on behalf of Daniel Stephenson