### PR TITLE
Say "source-available" instead of "open source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The Preponderous Software website is a [Next.js](https://nextjs.org/) web application that serves as the public face of Preponderous Software. It showcases the projects — free and open-source games, simulations, and libraries — and links out to their source on GitHub. Built with React and [Material UI](https://mui.com/), it mirrors the structure of the [Dan's Plugins Community website](https://github.com/Dans-Plugins/dansplugins-dot-com).
+The Preponderous Software website is a [Next.js](https://nextjs.org/) web application that serves as the public face of Preponderous Software. It showcases the projects — free, source-available games, simulations, and libraries — and links out to their source on GitHub. Built with React and [Material UI](https://mui.com/), it mirrors the structure of the [Dan's Plugins Community website](https://github.com/Dans-Plugins/dansplugins-dot-com).
 
 ## Installation
 

--- a/__tests__/Blurb.test.tsx
+++ b/__tests__/Blurb.test.tsx
@@ -16,6 +16,6 @@ describe('Blurb', () => {
         render(<Blurb />);
         expect(screen.getByText('Contribute')).toBeInTheDocument();
         expect(screen.getByText('Explore the Code')).toBeInTheDocument();
-        expect(screen.getByText('Free & Open Source')).toBeInTheDocument();
+        expect(screen.getByText('Source Available')).toBeInTheDocument();
     });
 });

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -75,7 +75,7 @@ const Blurb: React.FC = () => (
                 color="text.secondary"
                 sx={{maxWidth: 640, mx: 'auto', fontWeight: 400}}
             >
-                Free and open-source games and assets — built in the open,
+                Free, source-available games and assets — built in the open,
                 and easy to run, extend, and contribute to.
             </Typography>
             <Stack
@@ -112,7 +112,7 @@ const Blurb: React.FC = () => (
             <InfoCard
                 icon={<GitHubIcon sx={infoCardIconSizeStyle}/>}
                 title="Contribute"
-                content="Join our open-source community on GitHub. Each project welcomes issues and pull requests."
+                content="Join our community on GitHub. Each project welcomes issues and pull requests."
                 href={ORG_URL}
             />
             <InfoCard
@@ -123,7 +123,7 @@ const Blurb: React.FC = () => (
             />
             <InfoCard
                 icon={<FavoriteIcon sx={infoCardIconSizeStyle}/>}
-                title="Free & Open Source"
+                title="Source Available"
                 content="Everything we make is free to use, modify, and self-host for non-commercial purposes."
             />
         </Grid>

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 // social) all show meaningful information. Render once near the top of each page.
 const SITE_NAME = 'Preponderous Software';
 const DEFAULT_DESCRIPTION =
-    'Free and open-source games and assets — built in the open and free to use.';
+    'Free, source-available games and assets — built in the open and free to use.';
 
 interface SeoProps {
     // Page-specific title; the site name is appended automatically. Omit on the


### PR DESCRIPTION
## Summary

The site is licensed under the **Preponderous Non-Commercial License** (free for non-commercial use, source viewable) — not an OSI-approved open-source license — and not every showcased project uses an OSS license. Calling the work "open source" overclaims, so this switches the user-facing copy to the accurate **"source-available"** framing.

- `components/Seo.tsx` — default meta description.
- `components/Blurb.tsx` — hero subtitle; the **"Free & Open Source"** info card is renamed **"Source Available"**; the Contribute card drops "open-source" → "Join our community on GitHub."
- `README.md` — project description.
- `__tests__/Blurb.test.tsx` — assert the renamed card title.

No license terms changed — only the wording that described them.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — vitest, 14 passing (Blurb test updated to the new title)
- [x] grep confirms no remaining "open source"/"open-source" in source or docs
- [x] Confirmed live on the dev server (CI runs the full `npm run build`)

drafted by Claude on behalf of Daniel Stephenson