### PR TITLE
Grant packages: write so CI can push the image to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least privilege by default; the docker job widens to packages: write.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,6 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main'
+    # Required to push the image to GitHub Container Registry; without this the
+    # default read-only token fails with "denied: installation not allowed to
+    # Create organization package".
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The `docker` job's push to GHCR has **failed on every `main` build** since the cutover:

```
denied: installation not allowed to Create organization package
```

Root cause: the workflow declared **no `permissions:`**, so `GITHUB_TOKEN` was read-only and couldn't create/push the org-scoped package — no image has ever been published to `ghcr.io/preponderous-software/preponderous-dot-org`.

## Change
- Workflow-level least-privilege default: `permissions: contents: read`.
- `docker` job widened to `contents: read` + `packages: write`.

## Verification
- [x] YAML parses; `permissions` blocks set as intended.
- [ ] **Push fix is verifiable only post-merge** — the `docker` job is `if: github.ref == 'refs/heads/main'`, so it does not run on this PR. The `test` job still runs here and should stay green.

## Caveats / alternatives
- If the org has **disabled** "Allow GitHub Actions to create and approve packages" (Org → Settings → Actions), `packages: write` alone won't be enough — an admin must enable it, or pre-create the package and grant this repo write access.
- The gateway deploys preponderous.org by **building from source**, so it does not consume GHCR. If publishing an image isn't actually wanted, an alternative fix is to drop the `docker` push job entirely (or make it `push: false` to keep Dockerfile-build validation). Happy to switch to that approach if preferred.

## Hold for human review
Touches `.github/workflows/*` — a do-not-auto-merge path. Not auto-merging.

drafted by Claude on behalf of Daniel Stephenson