### PR TITLE
Add a Barony project card with a Visit Site button (#51)

### DIFF
--- a/__tests__/ProjectCard.test.tsx
+++ b/__tests__/ProjectCard.test.tsx
@@ -32,4 +32,34 @@ describe('ProjectCard', () => {
         expect(link).toHaveAttribute('target', '_blank');
         expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
     });
+
+    it('omits the Visit Site button when no websiteLink is given', () => {
+        render(
+            <ProjectCard
+                title="Roam"
+                description="Explore a procedurally-generated 2D world."
+                githubLink="https://github.com/Preponderous-Software/Roam"
+                technology="Python"
+            />
+        );
+        expect(screen.queryByRole('link', { name: /visit site/i })).toBeNull();
+    });
+
+    it('renders a Visit Site button linking to the live site in a new tab when websiteLink is set', () => {
+        render(
+            <ProjectCard
+                title="Barony"
+                description="Command armies to capture villages and castles against an AI opponent."
+                githubLink="https://github.com/Preponderous-Software/barony"
+                technology="Java"
+                websiteLink="https://barony.preponderous.org"
+            />
+        );
+        const site = screen.getByRole('link', { name: /visit site/i });
+        expect(site).toHaveAttribute('href', 'https://barony.preponderous.org');
+        expect(site).toHaveAttribute('target', '_blank');
+        expect(site).toHaveAttribute('rel', expect.stringContaining('noopener'));
+        // GitHub button still present alongside it
+        expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
+    });
 });

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Avatar, Box, Button, Card, CardActions, CardContent, Chip, Link, Stack, Typography} from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import CodeIcon from '@mui/icons-material/Code';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {
     projectCardStyle,
     projectCardContentStyle,
@@ -13,6 +14,9 @@ interface ProjectCardProps {
     description: string;
     githubLink: string;
     technology: string;
+    // Optional link to a live/hosted version of the project; when set, the card
+    // shows a "Visit Site" button as the primary action.
+    websiteLink?: string;
 }
 
 // A small, fixed palette of muted brand-ish colours. Each project gets a stable
@@ -28,7 +32,7 @@ const colorForTitle = (title: string): string => {
     return AVATAR_COLORS[hash % AVATAR_COLORS.length];
 };
 
-const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink, technology}) => {
+const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink, technology, websiteLink}) => {
     return (
         <Card sx={projectCardStyle}>
             <CardContent sx={projectCardContentStyle}>
@@ -79,8 +83,21 @@ const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink
 
             <CardActions sx={projectCardActionsStyle}>
                 <Box sx={{flexGrow: 1}}/>
+                {websiteLink ? (
+                    <Button
+                        variant="contained"
+                        size="small"
+                        startIcon={<OpenInNewIcon/>}
+                        component={Link}
+                        href={websiteLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Visit Site
+                    </Button>
+                ) : null}
                 <Button
-                    variant="contained"
+                    variant={websiteLink ? 'outlined' : 'contained'}
                     size="small"
                     startIcon={<GitHubIcon/>}
                     component={Link}

--- a/pages/data/projects.json
+++ b/pages/data/projects.json
@@ -8,6 +8,14 @@
       "technology": "Python"
     },
     {
+      "id": "barony",
+      "title": "Barony",
+      "description": "Command armies to capture villages and castles against an AI opponent.",
+      "githubLink": "https://github.com/Preponderous-Software/barony",
+      "technology": "Java",
+      "websiteLink": "https://barony.preponderous.org"
+    },
+    {
       "id": "beyond-nations",
       "title": "Beyond-Nations",
       "description": "Sandbox Nation Simulation RPG",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,6 +42,7 @@ const ProjectsSection: React.FC<{projects: Project[]}> = ({projects}) => (
                         description={project.description}
                         githubLink={project.githubLink}
                         technology={project.technology}
+                        websiteLink={project.websiteLink}
                     />
                 </Grid>
             ))}

--- a/utils/projects.ts
+++ b/utils/projects.ts
@@ -7,6 +7,8 @@ export interface Project {
     description: string;
     githubLink: string;
     technology: string;
+    // Optional link to a live/hosted version of the project.
+    websiteLink?: string;
 }
 
 // Sort projects alphabetically by title, case-insensitively. Returns a new


### PR DESCRIPTION
## Summary

Adds a **Barony** project card whose primary button opens the live site, per #51.

- `components/ProjectCard.tsx` — new optional `websiteLink` prop. When set, the card renders a contained **"Visit Site"** button (new tab, `rel="noopener noreferrer"`) and the GitHub button becomes `outlined`. Cards without `websiteLink` render exactly as before (GitHub stays contained, no extra button).
- `utils/projects.ts` (`Project` type) + `pages/index.tsx` thread the optional field through.
- `pages/data/projects.json` — Barony entry: repo `Preponderous-Software/barony`, technology **Java**, `websiteLink: https://barony.preponderous.org`.
- `__tests__/ProjectCard.test.tsx` — new cases: button absent when no `websiteLink`, and present + correctly linked (href/target/rel) with GitHub still alongside.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — vitest, **16 passing** (ProjectCard now 4)
- [x] `npm run build` runs in CI (not run locally — a `next dev` preview is live and shares `.next`)
- [x] Confirmed live on the dev server: Barony card renders with the Visit Site link to barony.preponderous.org

## Notes
Mirrors the `dansplugins-dot-com` multi-action-button card pattern. barony.preponderous.org is already live (served via the gateway).

Closes #51.

drafted by Claude on behalf of Daniel Stephenson