### PR TITLE
Drop the GHCR image push job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
 
-# Least privilege by default; the docker job widens to packages: write.
+# Least privilege: CI only checks out and runs the npm build/test.
 permissions:
   contents: read
 
@@ -34,47 +34,3 @@ jobs:
 
     - name: Build
       run: npm run build
-
-  docker:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.ref == 'refs/heads/main'
-    # Required to push the image to GitHub Container Registry; without this the
-    # default read-only token fails with "denied: installation not allowed to
-    # Create organization package".
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ghcr.io/${{ github.repository }}
-        tags: |
-          type=ref,event=branch
-          type=sha,prefix={{branch}}-
-          type=raw,value=latest,enable={{is_default_branch}}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Removes the `docker` job from CI. The gateway serves preponderous.org by **building the site from source** on the box, so the published GHCR image was never consumed — the job only produced an unused artifact (and, before #50, was the source of red CI).

- Delete the `docker` build/push job entirely.
- CI is now just the `test` job: `npm ci` → lint → test → build.
- Keep the workflow-level least-privilege `permissions: contents: read`; `packages: write` is removed along with the job.

The Dockerfile is still exercised for real on **every gateway deploy** (build-from-source, health-gated with auto-rollback), so dropping the CI image build doesn't leave it unvalidated in practice.

## Test plan
- [x] YAML parses; only the `test` job remains.
- [x] `test` job runs on this PR and should stay green (unchanged).

## Alternative (not taken)
Could instead keep a `push: false` build job to validate the Dockerfile in CI; given the gateway always builds it on deploy, that seemed redundant. Easy to add back if you'd prefer CI-side Dockerfile validation.

## Hold for human review
Touches `.github/workflows/*` (do-not-auto-merge).

drafted by Claude on behalf of Daniel Stephenson