### PR TITLE
Document the optional websiteLink project field in CONFIG.md

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -23,6 +23,7 @@ The file contains a single `projects` array. Each entry supports these fields:
 | `description` | yes | Short description. Clamped to three lines on the card. |
 | `githubLink` | yes | URL to the project's source repository (opens in a new tab). |
 | `technology` | yes | Primary language/technology, shown as a chip (e.g. `Python`, `Java`, `C++`). |
+| `websiteLink` | no | URL to a live/hosted version of the project. When set, the card shows a "Visit Site" button as its primary action, opening in a new tab. |
 
 Projects are sorted alphabetically by title at render time (see `utils/projects.ts`), so entries may be listed in any order.
 
@@ -30,11 +31,12 @@ Projects are sorted alphabetically by title at render time (see `utils/projects.
 
 ```json
 {
-  "id": "viron",
-  "title": "Viron",
-  "description": "Viron is a flexible simulation framework for building and managing 2D virtual environments.",
-  "githubLink": "https://github.com/Preponderous-Software/Viron",
-  "technology": "Java"
+  "id": "roam",
+  "title": "Roam",
+  "description": "Explore a procedurally-generated 2D world and interact with your surroundings.",
+  "githubLink": "https://github.com/Preponderous-Software/Roam",
+  "technology": "Python",
+  "websiteLink": "https://roam.preponderous.org"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Adds a `websiteLink` row to CONFIG.md's project field table, describing the optional field that renders a "Visit Site" button on project cards (already implemented in `components/ProjectCard.tsx` and already used for several entries in `pages/data/projects.json`, e.g. Barony, Roam).
- Swaps the example entry to one that includes `websiteLink` (Roam) so the docs demonstrate the optional field in context.

## Test plan
- [x] Verified `websiteLink` is a real, already-implemented prop in `components/ProjectCard.tsx` (renders "Visit Site" button when set)
- [x] Verified `websiteLink` is already used in `pages/data/projects.json` (Barony, microbiome, Roam, daniel-stephenson, dans-plugins-community)
- [ ] `npm ci` / `npm run lint` / `npm test` / `npm run build` — UNVERIFIED locally (npm unavailable in this sandbox without interactive approval); this is a docs-only change touching no source/config files, so CI is the anchor for this PR

Closes #55

## Deferred this cycle
Other open issues (#17 dynamic /projects route, #18 /about page, #19 /contact page, #20 footer improvements, #21 /legal route, #28 staging environment) are all substantial new-page/design/infra work — out of scope for a single polish-sized autonomous PR this cycle. Deferred, not evaluated as low-value.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
