### PR TITLE
Add a /legal page and flesh out the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - Documentation set: `README`, `CONFIG.md`, `USER_GUIDE.md`, `CONTRIBUTING.md`, and this changelog (#39).
 - Component-render test coverage for `ProjectCard` and `Blurb` using React Testing Library + jsdom (#38).
 - Node-based `Dockerfile`, `compose.yaml`, and dev container; CI switched to npm (#40).
+- `/legal` page covering the license, copyright, disclaimer, privacy (what is stored on the visitor's device), and third-party component notices (#21).
+- Footer copyright notice with a license link, plus **Home** and **Legal** navigation links; the copyright year is baked in at build time via `NEXT_PUBLIC_BUILD_YEAR` (#20).
 
 ### Removed
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -4,7 +4,13 @@ This document describes the configuration options for the Preponderous Software 
 
 ## Environment Variables
 
-The site is a static project showcase and currently requires **no environment variables** to build or run. If configurable values are added in the future, create a `.env.local` file in the project root (it is excluded from version control) and document the variables here.
+The site is a static project showcase and requires **no environment variables** to build or run. If configurable values are added in the future, create a `.env.local` file in the project root (it is excluded from version control) and document the variables here.
+
+One value is injected automatically by `next.config.js` and does not need to be set by hand:
+
+| Variable | Set by | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_BUILD_YEAR` | `next.config.js`, at build time | The year the site was built, used for the copyright range in the footer and on `/legal`. Baked in at build time so the pre-rendered HTML and the client hydration pass always agree; reading the clock during render would disagree across a New Year boundary. If it is ever missing, `utils/copyright.ts` falls back to the current year. |
 
 ## Project Showcase Data
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -32,6 +32,12 @@ You can also reach the full GitHub organization via the **GitHub** link in the t
 1. Use the sun/moon toggle in the top (or bottom) navigation bar.
 2. Your choice is remembered for future visits. If you've never chosen, the site follows your operating system's light/dark preference.
 
+### Viewing Licensing and Privacy Information
+
+1. Click **Legal** in the footer, or the license name next to the copyright notice.
+2. The **/legal** page covers the license the projects are published under, the copyright and disclaimer, what the site stores on your device (only your light/dark preference), and the third-party components the site is built with.
+3. Links to the full license text open in a new tab.
+
 ### Reporting a Website Bug
 
 If you find a bug on the website itself:

--- a/__tests__/BottomBar.test.tsx
+++ b/__tests__/BottomBar.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BottomBar from '../components/BottomBar';
+import { formatCopyright, LICENSE_SHORT_NAME } from '../utils/copyright';
+
+describe('BottomBar', () => {
+    beforeEach(() => {
+        render(<BottomBar version="1.2.3"/>);
+    });
+
+    it('shows the version it was given', () => {
+        expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+    });
+
+    it('shows the copyright notice with the license linking to /legal', () => {
+        expect(screen.getByText(formatCopyright(), { exact: false })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: LICENSE_SHORT_NAME })).toHaveAttribute('href', '/legal');
+    });
+
+    it('keeps internal footer links in the same tab', () => {
+        for (const [name, href] of [[/home/i, '/'], [/legal/i, '/legal']] as const) {
+            const link = screen.getByRole('link', { name });
+            expect(link).toHaveAttribute('href', href);
+            expect(link).not.toHaveAttribute('target');
+            expect(link).not.toHaveAttribute('rel');
+        }
+    });
+
+    it('opens external footer links in a new tab with rel="noopener noreferrer"', () => {
+        for (const name of [/source code/i, /report a bug/i]) {
+            const link = screen.getByRole('link', { name });
+            expect(link).toHaveAttribute('href', expect.stringContaining('https://github.com/'));
+            expect(link).toHaveAttribute('target', '_blank');
+            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        }
+    });
+
+    it('labels the footer link group as navigation', () => {
+        expect(screen.getByRole('navigation', { name: /footer/i })).toBeInTheDocument();
+    });
+
+    it('renders the color-mode toggle', () => {
+        expect(screen.getByRole('checkbox', { name: /toggle dark mode/i })).toBeInTheDocument();
+    });
+});

--- a/__tests__/copyright.test.ts
+++ b/__tests__/copyright.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    COPYRIGHT_HOLDER,
+    COPYRIGHT_START_YEAR,
+    formatCopyright,
+    getBuildYear,
+} from '../utils/copyright';
+
+const setBuildYear = (value: string | undefined) => {
+    if (value === undefined) {
+        delete process.env.NEXT_PUBLIC_BUILD_YEAR;
+    } else {
+        process.env.NEXT_PUBLIC_BUILD_YEAR = value;
+    }
+};
+
+describe('formatCopyright', () => {
+    it('renders a year range from the first year of publication', () => {
+        expect(formatCopyright(2026)).toBe(`© ${COPYRIGHT_START_YEAR}–2026 ${COPYRIGHT_HOLDER}`);
+    });
+
+    it('collapses to a single year during the first year of publication', () => {
+        expect(formatCopyright(COPYRIGHT_START_YEAR)).toBe(`© ${COPYRIGHT_START_YEAR} ${COPYRIGHT_HOLDER}`);
+    });
+
+    it('never renders a backwards range for a year before publication', () => {
+        expect(formatCopyright(COPYRIGHT_START_YEAR - 3)).toBe(`© ${COPYRIGHT_START_YEAR} ${COPYRIGHT_HOLDER}`);
+    });
+});
+
+describe('getBuildYear', () => {
+    const original = process.env.NEXT_PUBLIC_BUILD_YEAR;
+
+    afterEach(() => {
+        setBuildYear(original);
+    });
+
+    it('uses the year injected at build time', () => {
+        setBuildYear('2030');
+        expect(getBuildYear()).toBe(2030);
+    });
+
+    it('falls back to the current year when the build year is absent', () => {
+        setBuildYear(undefined);
+        expect(getBuildYear()).toBe(new Date().getFullYear());
+    });
+
+    it('falls back to the current year when the build year is not a usable number', () => {
+        setBuildYear('not-a-year');
+        expect(getBuildYear()).toBe(new Date().getFullYear());
+
+        setBuildYear(String(COPYRIGHT_START_YEAR - 1));
+        expect(getBuildYear()).toBe(new Date().getFullYear());
+    });
+});

--- a/__tests__/legal.test.tsx
+++ b/__tests__/legal.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LegalPage from '../pages/legal';
+import { COLOR_MODE_STORAGE_KEY } from '../utils/colorMode';
+import { COPYRIGHT_HOLDER, LICENSE_URL, formatCopyright } from '../utils/copyright';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/legal' }),
+}));
+
+describe('Legal page', () => {
+    beforeEach(() => {
+        render(<LegalPage/>);
+    });
+
+    it('renders a Legal heading and the licensing sections', () => {
+        expect(screen.getByRole('heading', { level: 1, name: 'Legal' })).toBeInTheDocument();
+        for (const title of ['License', 'Copyright', 'Disclaimer', 'Privacy', 'Third-Party Software', 'Questions']) {
+            expect(screen.getByRole('heading', { level: 2, name: title })).toBeInTheDocument();
+        }
+    });
+
+    it('links to the canonical license text in a new tab', () => {
+        const link = screen.getByRole('link', { name: /full preponderous-nc license text/i });
+        expect(link).toHaveAttribute('href', LICENSE_URL);
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('states the copyright and the "not a legal entity" disclaimer', () => {
+        // Twice over: once in the Copyright section, once in the footer's notice.
+        expect(screen.getAllByText(formatCopyright(), { exact: false })).toHaveLength(2);
+        expect(
+            screen.getByText(/Preponderous Software is not a legal entity/i)
+        ).toBeInTheDocument();
+        expect(screen.getAllByText(new RegExp(COPYRIGHT_HOLDER)).length).toBeGreaterThan(0);
+    });
+
+    it('names the only value stored on the visitor\'s device', () => {
+        expect(screen.getByText(COLOR_MODE_STORAGE_KEY)).toBeInTheDocument();
+    });
+
+    it('credits the third-party components the site is built on', () => {
+        for (const name of ['Next.js', 'React', 'Material UI', 'Emotion']) {
+            expect(screen.getByRole('link', { name })).toBeInTheDocument();
+        }
+    });
+});

--- a/components/BottomBar.tsx
+++ b/components/BottomBar.tsx
@@ -1,9 +1,12 @@
-import {AppBar, Box, Button, Toolbar, Typography, useTheme} from '@mui/material';
+import {AppBar, Box, Button, Link, Toolbar, Typography, useTheme} from '@mui/material';
 import React, {useContext} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
 import CodeIcon from '@mui/icons-material/Code';
 import BugReportIcon from '@mui/icons-material/BugReport';
+import GavelIcon from '@mui/icons-material/Gavel';
+import HomeIcon from '@mui/icons-material/Home';
+import {formatCopyright, LICENSE_SHORT_NAME} from '../utils/copyright';
 
 import {
     toolbarStyle,
@@ -14,19 +17,43 @@ import {
     flexContainerStyle
 } from '../styles/styles';
 
+// Internal routes (e.g. /legal) navigate in the same tab; off-site links open in
+// a new tab with rel="noopener noreferrer", matching TopBar's NavButton.
 const FooterButton: React.FC<{ href: string; icon: React.ReactNode; children: React.ReactNode }> = ({
     href,
     icon,
     children,
-}) => (
-    <Button color="inherit" href={href} target="_blank" rel="noopener noreferrer" startIcon={icon} sx={(theme) => footerButtonStyle(theme)}>
-        {children}
-    </Button>
-);
+}) => {
+    const isExternal = href.startsWith('http');
+    return (
+        <Button
+            color="inherit"
+            href={href}
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}
+            startIcon={icon}
+            sx={(theme) => footerButtonStyle(theme)}
+        >
+            {children}
+        </Button>
+    );
+};
 
 const VersionNumber: React.FC<{ version: string }> = ({version}) => (
     <Typography variant="body1" color="inherit" component="div" sx={(theme) => versionNumberStyle(theme)}>
         v{version}
+    </Typography>
+);
+
+// Copyright holder plus the license the site is published under, with the
+// license name linking to the fuller explanation on /legal.
+const CopyrightNotice: React.FC = () => (
+    <Typography variant="body2" color="inherit" component="div" sx={{opacity: 0.85}}>
+        {formatCopyright()}
+        {' · '}
+        <Link href="/legal" color="inherit" underline="always">
+            {LICENSE_SHORT_NAME}
+        </Link>
     </Typography>
 );
 
@@ -39,14 +66,21 @@ const BottomBar: React.FC<BottomBarProps> = ({version}) => {
     const theme = useTheme();
 
     return (
-        <AppBar position="static" sx={(theme) => bottomAppBarStyle(theme)}>
+        <AppBar position="static" component="footer" sx={(theme) => bottomAppBarStyle(theme)}>
             <Toolbar sx={(theme) => toolbarStyle(theme)}>
                 <Box sx={(theme) => flexContainerStyle(theme)}>
-                    <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
+                    <Box sx={(theme) => flexContainerStyle(theme, {gap: 2})}>
                         <VersionNumber version={version}/>
+                        <CopyrightNotice/>
                     </Box>
 
-                    <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
+                    <Box component="nav" aria-label="Footer" sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
+                        <FooterButton href="/" icon={<HomeIcon/>}>
+                            Home
+                        </FooterButton>
+                        <FooterButton href="/legal" icon={<GavelIcon/>}>
+                            Legal
+                        </FooterButton>
                         <FooterButton
                             href="https://github.com/Preponderous-Software/preponderous-dot-org"
                             icon={<CodeIcon/>}

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,12 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: false,
+  env: {
+    // Baked into both the server and client bundles at build time, so the
+    // copyright year in the footer/legal page can never differ between the
+    // pre-rendered HTML and the client hydration pass.
+    NEXT_PUBLIC_BUILD_YEAR: String(new Date().getFullYear()),
+  },
 }
 
 module.exports = nextConfig

--- a/pages/legal.tsx
+++ b/pages/legal.tsx
@@ -1,0 +1,161 @@
+import type {NextPage} from 'next';
+import {Box, Container, Link, List, ListItem, Typography} from '@mui/material';
+import React from 'react';
+import TopBar from '../components/TopBar';
+import BottomBar from '../components/BottomBar';
+import Seo from '../components/Seo';
+import {COLOR_MODE_STORAGE_KEY} from '../utils/colorMode';
+import {
+    COPYRIGHT_HOLDER,
+    LICENSE_NAME,
+    LICENSE_SHORT_NAME,
+    LICENSE_URL,
+    formatCopyright,
+} from '../utils/copyright';
+import {pageStyle, sectionHeaderStyle, sectionDividerStyle} from '../styles/styles';
+
+// pull the displayed version from package.json so the footer stays in sync
+const version = require('../package.json').version;
+
+const REPO_URL = 'https://github.com/Preponderous-Software/preponderous-dot-org';
+
+const LegalSection: React.FC<{title: string; children: React.ReactNode}> = ({title, children}) => (
+    <Box component="section" sx={{mb: 5}}>
+        <Typography variant="h5" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            {title}
+        </Typography>
+        {children}
+    </Box>
+);
+
+const Paragraph: React.FC<{children: React.ReactNode}> = ({children}) => (
+    <Typography variant="body1" color="text.secondary" sx={{mb: 2}}>
+        {children}
+    </Typography>
+);
+
+// Third-party components this site is built on. Listed here rather than
+// generated from package.json so the notice stays a deliberate, reviewed
+// statement about the runtime dependencies visitors actually receive.
+const THIRD_PARTY = [
+    {name: 'Next.js', license: 'MIT', href: 'https://github.com/vercel/next.js/blob/canary/license.md'},
+    {name: 'React', license: 'MIT', href: 'https://github.com/facebook/react/blob/main/LICENSE'},
+    {name: 'Material UI', license: 'MIT', href: 'https://github.com/mui/material-ui/blob/master/LICENSE'},
+    {name: 'Emotion', license: 'MIT', href: 'https://github.com/emotion-js/emotion/blob/main/LICENSE'},
+];
+
+const LegalPage: NextPage = () => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo
+            title="Legal"
+            description="Licensing, copyright, and privacy information for Preponderous Software."
+        />
+        <TopBar/>
+        <Container component="main" id="main" maxWidth="md" sx={{py: 4, flexGrow: 1}}>
+            <Typography variant="h3" component="h1" gutterBottom sx={{fontWeight: 700, letterSpacing: '-0.01em'}}>
+                Legal
+            </Typography>
+            <Paragraph>
+                Licensing, copyright, and privacy information for this website and the projects
+                showcased on it.
+            </Paragraph>
+            <Box sx={(theme) => sectionDividerStyle(theme)}/>
+
+            <LegalSection title="License">
+                <Paragraph>
+                    This website and the projects published by Preponderous Software are released
+                    under the {LICENSE_NAME}. It is a source-available license: the work is free to
+                    use, modify, and self-host for <strong>non-commercial</strong> purposes, and
+                    commercial use requires a separate license.
+                </Paragraph>
+                <Paragraph>
+                    The canonical license text is the authoritative version — the summary above is
+                    for orientation only and does not replace it.
+                </Paragraph>
+                <List dense disablePadding>
+                    <ListItem disableGutters>
+                        <Link href={LICENSE_URL} target="_blank" rel="noopener noreferrer">
+                            Full {LICENSE_SHORT_NAME} license text
+                        </Link>
+                    </ListItem>
+                    <ListItem disableGutters>
+                        <Link href={`${REPO_URL}/blob/main/LICENSE`} target="_blank" rel="noopener noreferrer">
+                            License as distributed with this website
+                        </Link>
+                    </ListItem>
+                </List>
+            </LegalSection>
+
+            <LegalSection title="Copyright">
+                <Paragraph>
+                    {formatCopyright()}. All rights reserved, except as granted by
+                    the {LICENSE_SHORT_NAME} license.
+                </Paragraph>
+                <Paragraph>
+                    Individual projects may carry their own notices; where a project&apos;s
+                    repository states otherwise, that repository governs.
+                </Paragraph>
+            </LegalSection>
+
+            <LegalSection title="Disclaimer">
+                <Paragraph>
+                    Preponderous Software is not a legal entity. All rights to works published under
+                    this name are reserved by the copyright holder, {COPYRIGHT_HOLDER}.
+                </Paragraph>
+                <Paragraph>
+                    The projects showcased here are provided &quot;as is&quot;, without warranty of
+                    any kind, to the extent permitted by applicable law.
+                </Paragraph>
+            </LegalSection>
+
+            <LegalSection title="Privacy">
+                <Paragraph>
+                    This website has no accounts, no advertising, and no analytics or tracking
+                    scripts. It does not collect personal information and sets no cookies.
+                </Paragraph>
+                <Paragraph>
+                    The only data stored on your device is your light/dark mode preference, saved in
+                    your browser&apos;s local storage under the
+                    key <code>{COLOR_MODE_STORAGE_KEY}</code>. It never leaves your browser, and
+                    clearing your browser&apos;s site data removes it.
+                </Paragraph>
+                <Paragraph>
+                    Following a link away from this site — for example to GitHub — hands you over to
+                    that service&apos;s own privacy policy.
+                </Paragraph>
+            </LegalSection>
+
+            <LegalSection title="Third-Party Software">
+                <Paragraph>
+                    This website is built with open-source components, each under its own license:
+                </Paragraph>
+                <List dense disablePadding>
+                    {THIRD_PARTY.map(({name, license, href}) => (
+                        <ListItem disableGutters key={name}>
+                            <Typography variant="body2" color="text.secondary">
+                                <Link href={href} target="_blank" rel="noopener noreferrer">
+                                    {name}
+                                </Link>
+                                {` — ${license} License`}
+                            </Typography>
+                        </ListItem>
+                    ))}
+                </List>
+            </LegalSection>
+
+            <LegalSection title="Questions">
+                <Paragraph>
+                    For licensing questions, or to report something on this page that looks wrong,
+                    open an issue on the{' '}
+                    <Link href={`${REPO_URL}/issues/new`} target="_blank" rel="noopener noreferrer">
+                        website repository
+                    </Link>
+                    .
+                </Paragraph>
+            </LegalSection>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default LegalPage;

--- a/utils/copyright.ts
+++ b/utils/copyright.ts
@@ -1,0 +1,41 @@
+// Licensing and copyright facts shared by the footer and the /legal page, kept
+// framework-free so the formatting helpers below stay pure and unit-testable.
+// The values mirror LICENSE in the repository root — update both together.
+
+export const COPYRIGHT_HOLDER = 'Daniel McCoy Stephenson';
+
+// First year of publication; the displayed range runs from here to the year the
+// site was built.
+export const COPYRIGHT_START_YEAR = 2022;
+
+export const LICENSE_NAME = 'Preponderous Non-Commercial License (Preponderous-NC)';
+export const LICENSE_SHORT_NAME = 'Preponderous-NC';
+export const LICENSE_URL =
+    'https://github.com/Preponderous-Software/preponderous-nc-license/blob/main/LICENSE.md';
+
+/**
+ * The year the site was built. Injected as a build-time constant by
+ * `next.config.js` so the pre-rendered HTML and the client hydration pass always
+ * agree — reading the clock during render would disagree across a New Year
+ * boundary and cause a hydration mismatch. Falls back to the current year when
+ * the constant is absent (e.g. under Vitest, which does not load next.config.js).
+ */
+export const getBuildYear = (): number => {
+    const injected = Number(process.env.NEXT_PUBLIC_BUILD_YEAR);
+    return Number.isInteger(injected) && injected >= COPYRIGHT_START_YEAR
+        ? injected
+        : new Date().getFullYear();
+};
+
+/**
+ * A copyright line such as `© 2022–2026 Daniel McCoy Stephenson`. Collapses to a
+ * single year while the current year is still the first year of publication (or
+ * if a stale/earlier year is somehow supplied).
+ */
+export const formatCopyright = (year: number = getBuildYear()): string => {
+    const range =
+        year > COPYRIGHT_START_YEAR
+            ? `${COPYRIGHT_START_YEAR}–${year}`
+            : `${COPYRIGHT_START_YEAR}`;
+    return `© ${range} ${COPYRIGHT_HOLDER}`;
+};


### PR DESCRIPTION
## Summary

- **New `/legal` route** (`pages/legal.tsx`) inside the standard page chrome (`Seo`, `TopBar`, `main#main`, `BottomBar`). Sections: License (Preponderous-NC summary with links to the canonical text and the copy distributed with the site), Copyright, Disclaimer ("Preponderous Software is not a legal entity"), Privacy, and Third-Party Software.
- **Privacy section is factual, not boilerplate**: it states there are no accounts, ads, analytics, or cookies, and names the one value the site stores on the visitor's device — the color-mode preference under `preponderous-color-mode` (`utils/colorMode.ts`).
- **`utils/copyright.ts`**: framework-free copyright/license constants plus `formatCopyright()` and `getBuildYear()`, shared by the footer and the legal page. `formatCopyright()` collapses to a single year rather than rendering a backwards range.
- **Footer** (`components/BottomBar.tsx`): copyright notice whose license name links to `/legal`, plus **Home** and **Legal** links; the link group is now a labelled `<nav>` and the bar renders as `<footer>`. `FooterButton` only forces `target="_blank"` / `rel="noopener noreferrer"` on off-site hrefs now, matching `TopBar`'s `NavButton` — previously it did so unconditionally, which would have opened `/legal` in a new tab.
- **Dynamic year without a hydration hazard**: `next.config.js` bakes `NEXT_PUBLIC_BUILD_YEAR` into both bundles at build time, so the pre-rendered HTML and the client hydration pass cannot disagree across a New Year boundary. `getBuildYear()` falls back to the current year when the constant is absent (e.g. under Vitest, which does not load `next.config.js`).
- **Docs**: `CHANGELOG.md` `[Unreleased]` entries for both changes, a "Viewing Licensing and Privacy Information" scenario in `USER_GUIDE.md`, and the injected build-time constant documented in `CONFIG.md` (which previously said no environment variables exist at all).

## Test plan

New tests, following the existing `ProjectCard.test.tsx` style:

- [ ] `__tests__/copyright.test.ts` — year range formatting, single-year collapse, no backwards range, and `getBuildYear()`'s injected value plus its fallbacks (absent / non-numeric / pre-publication).
- [ ] `__tests__/BottomBar.test.tsx` — version string, copyright notice with the license link to `/legal`, internal links staying in the same tab, external links carrying `target="_blank"` + `rel="noopener noreferrer"`, the labelled footer `<nav>`, and the color-mode toggle.
- [ ] `__tests__/legal.test.tsx` — headings, canonical license link opening in a new tab, copyright + disclaimer text, the named storage key, and the third-party credits (`next/router` mocked for `TopBar`).
- [ ] CI (`npm run lint`, `npm test`, `npm run build`) passes.

> **Note on local verification:** the environment this branch was authored in has no Node/npm available, so `npm run lint`, `npm test`, `npx tsc --noEmit`, and `npm run build` could **not** be run locally. Verification for this PR is CI (`.github/workflows/ci.yml` runs all four on pull requests); the boxes above are left unchecked deliberately and any CI failure will be fixed on this branch before merge.

Closes #21
Closes #20

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
