### PR TITLE
Guard color-mode storage access and test the _app wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - Friendly themed `404` and `500` error pages within the standard chrome (#37).
 - GitHub Actions CI: lint, test, and build on pull requests and `main` (#27, #53).
 - Documentation set: `README`, `CONFIG.md`, `USER_GUIDE.md`, `CONTRIBUTING.md`, and this changelog (#39).
-- Component-render test coverage for `ProjectCard` and `Blurb` using React Testing Library + jsdom (#38), extended to the shared chrome — `TopBar`, `BottomBar`, `Seo`, and `ErrorPage` (#58).
+- Component-render test coverage for `ProjectCard` and `Blurb` using React Testing Library + jsdom (#38), extended to the shared chrome — `TopBar`, `BottomBar`, `Seo`, and `ErrorPage` (#58) — and to the color-mode wiring in `_app` (#62).
 - Node-based `Dockerfile`, `compose.yaml`, and dev container; CI switched to npm (#40).
 - `/legal` page covering the license, copyright, disclaimer, privacy (what is stored on the visitor's device), and third-party component notices (#21).
 - Footer copyright notice with a license link, plus **Home** and **Legal** navigation links; the copyright year is baked in at build time via `NEXT_PUBLIC_BUILD_YEAR` (#20).
@@ -29,6 +29,10 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 ### Changed
 
 - The site now describes its projects as "source-available" rather than "open source", both in the home-page blurb and in the default page description (#49).
+
+### Fixed
+
+- The light/dark toggle no longer stops working in browsers that block site data: reading and writing the saved preference is now guarded, so the mode still switches when it cannot be persisted (#61).
 
 ### Removed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -41,6 +41,7 @@ Cards without a **Visit Site** button have no hosted version — use the **GitHu
 
 1. Use the sun/moon toggle in the top (or bottom) navigation bar.
 2. Your choice is remembered for future visits. If you've never chosen, the site follows your operating system's light/dark preference.
+3. If your browser is set to block site data, the toggle still switches the mode for as long as you're on the page — the choice simply isn't remembered.
 
 ### Viewing Licensing and Privacy Information
 

--- a/__tests__/_app.test.tsx
+++ b/__tests__/_app.test.tsx
@@ -1,0 +1,142 @@
+import React, { useContext } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useTheme } from '@mui/material';
+import type { AppProps } from 'next/app';
+import MyApp from '../pages/_app';
+import { ColorModeContext } from '../utils/ColorModeContext';
+import { COLOR_MODE_STORAGE_KEY } from '../utils/colorMode';
+
+// A stand-in page that reports the palette mode MyApp resolved and exposes the
+// toggle, so the tests can observe and drive the color-mode wiring.
+const ProbePage = () => {
+    const theme = useTheme();
+    const { toggleColorMode } = useContext(ColorModeContext);
+    return (
+        <main id="main">
+            <span data-testid="mode">{theme.palette.mode}</span>
+            <button onClick={toggleColorMode}>Toggle</button>
+        </main>
+    );
+};
+
+const renderApp = () =>
+    render(
+        <MyApp
+            {...({ Component: ProbePage, pageProps: {} } as unknown as AppProps)}
+        />
+    );
+
+const currentMode = () => screen.getByTestId('mode').textContent;
+
+// jsdom's matchMedia support is not something these tests should depend on, so
+// every case states the OS preference explicitly — including its absence.
+const stubPrefersDark = (prefersDark: boolean) => {
+    vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: prefersDark })));
+};
+
+const stubNoMatchMedia = () => {
+    vi.stubGlobal('matchMedia', undefined);
+};
+
+// Stands in for a browser that blocks site data: touching storage throws
+// instead of returning a value (SecurityError / QuotaExceededError).
+const stubThrowingStorage = () => {
+    vi.stubGlobal('localStorage', {
+        getItem: () => {
+            throw new Error('SecurityError');
+        },
+        setItem: () => {
+            throw new Error('QuotaExceededError');
+        },
+    });
+};
+
+describe('MyApp', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('renders the page inside the shared chrome', () => {
+        stubPrefersDark(true);
+        renderApp();
+        expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute('href', '#main');
+        expect(screen.getByTestId('mode')).toBeInTheDocument();
+    });
+
+    it('honours a saved "light" choice over the OS preference', () => {
+        window.localStorage.setItem(COLOR_MODE_STORAGE_KEY, 'light');
+        stubPrefersDark(true);
+        renderApp();
+        expect(currentMode()).toBe('light');
+    });
+
+    it('honours a saved "dark" choice over the OS preference', () => {
+        window.localStorage.setItem(COLOR_MODE_STORAGE_KEY, 'dark');
+        stubPrefersDark(false);
+        renderApp();
+        expect(currentMode()).toBe('dark');
+    });
+
+    it('follows a dark OS preference for a first-time visitor', () => {
+        stubPrefersDark(true);
+        renderApp();
+        expect(currentMode()).toBe('dark');
+    });
+
+    it('follows a light OS preference for a first-time visitor', () => {
+        stubPrefersDark(false);
+        renderApp();
+        expect(currentMode()).toBe('light');
+    });
+
+    it('falls back to dark when the browser cannot report an OS preference', () => {
+        stubNoMatchMedia();
+        renderApp();
+        expect(currentMode()).toBe('dark');
+    });
+
+    it('flips the mode and persists the choice when toggled', () => {
+        stubPrefersDark(true);
+        renderApp();
+        expect(currentMode()).toBe('dark');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+
+        expect(currentMode()).toBe('light');
+        expect(window.localStorage.getItem(COLOR_MODE_STORAGE_KEY)).toBe('light');
+    });
+
+    it('flips back on a second toggle', () => {
+        stubPrefersDark(false);
+        renderApp();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+
+        expect(currentMode()).toBe('light');
+        expect(window.localStorage.getItem(COLOR_MODE_STORAGE_KEY)).toBe('light');
+    });
+
+    it('still follows the OS preference when storage reads are blocked', () => {
+        stubThrowingStorage();
+        stubPrefersDark(false);
+        renderApp();
+        expect(currentMode()).toBe('light');
+    });
+
+    it('still toggles when the choice cannot be persisted', () => {
+        stubThrowingStorage();
+        stubPrefersDark(true);
+        renderApp();
+        expect(currentMode()).toBe('dark');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+
+        expect(currentMode()).toBe('light');
+    });
+});

--- a/__tests__/colorMode.test.ts
+++ b/__tests__/colorMode.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from 'vitest';
-import { resolveInitialColorMode } from '../utils/colorMode';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    COLOR_MODE_STORAGE_KEY,
+    readStoredColorMode,
+    resolveInitialColorMode,
+    storeColorMode,
+} from '../utils/colorMode';
+
+// Stands in for a browser that blocks site data: touching storage throws
+// instead of returning a value (SecurityError / QuotaExceededError).
+const stubThrowingStorage = () => {
+    vi.stubGlobal('localStorage', {
+        getItem: () => {
+            throw new Error('SecurityError');
+        },
+        setItem: () => {
+            throw new Error('QuotaExceededError');
+        },
+    });
+};
 
 describe('resolveInitialColorMode', () => {
     it('honours a saved "light" choice regardless of OS preference', () => {
@@ -20,5 +38,55 @@ describe('resolveInitialColorMode', () => {
     it('ignores an unrecognised stored value and uses the OS preference', () => {
         expect(resolveInitialColorMode('purple', false)).toBe('light');
         expect(resolveInitialColorMode('', true)).toBe('dark');
+    });
+});
+
+describe('readStoredColorMode', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns null when nothing has been saved', () => {
+        expect(readStoredColorMode()).toBeNull();
+    });
+
+    it('returns the saved value', () => {
+        window.localStorage.setItem(COLOR_MODE_STORAGE_KEY, 'light');
+        expect(readStoredColorMode()).toBe('light');
+    });
+
+    it('returns null instead of throwing when storage access is blocked', () => {
+        stubThrowingStorage();
+        expect(readStoredColorMode()).toBeNull();
+    });
+});
+
+describe('storeColorMode', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('saves the mode under the shared storage key', () => {
+        storeColorMode('light');
+        expect(window.localStorage.getItem(COLOR_MODE_STORAGE_KEY)).toBe('light');
+    });
+
+    it('overwrites a previously saved mode', () => {
+        storeColorMode('light');
+        storeColorMode('dark');
+        expect(window.localStorage.getItem(COLOR_MODE_STORAGE_KEY)).toBe('dark');
+    });
+
+    it('does not throw when the write is rejected', () => {
+        stubThrowingStorage();
+        expect(() => storeColorMode('dark')).not.toThrow();
     });
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,7 @@ import type {AppProps} from 'next/app'
 import React, {useEffect, useMemo, useState} from 'react';
 import {Box, createTheme, CssBaseline, ThemeProvider} from '@mui/material';
 import {ColorModeContext} from '../utils/ColorModeContext';
-import {COLOR_MODE_STORAGE_KEY, ColorMode, resolveInitialColorMode} from '../utils/colorMode';
+import {ColorMode, readStoredColorMode, resolveInitialColorMode, storeColorMode} from '../utils/colorMode';
 import '../styles/globals.css';
 
 function MyApp({Component, pageProps}: AppProps) {
@@ -13,25 +13,27 @@ function MyApp({Component, pageProps}: AppProps) {
     const [mode, setMode] = useState<ColorMode>('dark');
 
     useEffect(() => {
-        const stored = window.localStorage.getItem(COLOR_MODE_STORAGE_KEY);
+        const stored = readStoredColorMode();
         const prefersDark = window.matchMedia
             ? window.matchMedia('(prefers-color-scheme: dark)').matches
             : true;
         setMode(resolveInitialColorMode(stored, prefersDark));
     }, []);
 
+    // Derived from the current mode rather than a state updater so that the
+    // (side-effecting, best-effort) write stays outside React's render path —
+    // under StrictMode an updater is invoked twice, and a persistence failure
+    // must never be able to interfere with the mode actually flipping.
     const colorMode = useMemo(
         () => ({
             toggleColorMode: () => {
-                setMode((prevMode) => {
-                    const nextMode: ColorMode = prevMode === 'light' ? 'dark' : 'light';
-                    // Persist the explicit choice so it survives navigation and reloads.
-                    window.localStorage.setItem(COLOR_MODE_STORAGE_KEY, nextMode);
-                    return nextMode;
-                });
+                const nextMode: ColorMode = mode === 'light' ? 'dark' : 'light';
+                setMode(nextMode);
+                // Persist the explicit choice so it survives navigation and reloads.
+                storeColorMode(nextMode);
             }
         }),
-        [],
+        [mode],
     );
 
     const theme = useMemo(

--- a/utils/colorMode.ts
+++ b/utils/colorMode.ts
@@ -20,3 +20,27 @@ export const resolveInitialColorMode = (
     }
     return prefersDark ? 'dark' : 'light';
 };
+
+// Read the saved color-mode choice. Merely touching window.localStorage throws
+// a SecurityError in browsers configured to block site data, so the access is
+// guarded: a failure (and a server-side call, where `window` is undefined) is
+// reported as "nothing saved" and the caller falls back to the OS preference.
+export const readStoredColorMode = (): string | null => {
+    try {
+        return window.localStorage.getItem(COLOR_MODE_STORAGE_KEY);
+    } catch {
+        return null;
+    }
+};
+
+// Persist an explicit color-mode choice. Best-effort by design: writing throws
+// when storage is blocked or full (QuotaExceededError), and a visitor who
+// cannot have the choice remembered should still be able to switch modes for
+// the current session.
+export const storeColorMode = (mode: ColorMode): void => {
+    try {
+        window.localStorage.setItem(COLOR_MODE_STORAGE_KEY, mode);
+    } catch {
+        // Ignored: persistence is a nice-to-have, switching modes is not.
+    }
+};


### PR DESCRIPTION
## Summary

- Add guarded `readStoredColorMode()` / `storeColorMode()` helpers to `utils/colorMode.ts`. Touching `window.localStorage` throws a `SecurityError` when a browser is configured to block site data, and `setItem` throws `QuotaExceededError` when storage is full or unavailable in private browsing; both accesses are now wrapped in `try`/`catch`, degrading to "not remembered" instead of "toggle is dead".
- `pages/_app.tsx` calls those helpers instead of reaching for `window.localStorage` directly, and the persistence write has moved out of the `setMode` updater — `toggleColorMode` now derives the next mode from the current `mode` (with `mode` added to the `useMemo` deps). Keeping the side effect out of the updater matters here because `next.config.js` sets `reactStrictMode: true`, which invokes updaters twice.
- Add `__tests__/_app.test.tsx`, the first coverage of `_app`'s color-mode wiring: saved choice wins over the OS preference, first-time visitors follow `prefers-color-scheme`, the `'dark'` fallback when the browser cannot report a preference, toggling flips and persists, and both blocked-storage paths still behave.
- Extend `__tests__/colorMode.test.ts` with unit tests for the two new helpers, including the throwing-storage case.
- Docs: note the blocked-site-data behavior in `USER_GUIDE.md`, and record the fix and the new coverage in `CHANGELOG.md` under `[Unreleased]`.

## Test plan

- [ ] `npm run lint` (CI)
- [ ] `npm test` (CI)
- [ ] `npm run build` (CI)

Note: the environment this branch was authored in has no Node toolchain available (no `npm`/`node`, no `node_modules`), so the suite was **not** run locally — CI on this PR is the verification gate. The `_app` tests deliberately stub `window.matchMedia` explicitly in every case (including stubbing it to `undefined` for the no-support branch) rather than relying on whatever jsdom does by default.

Closes #61
Closes #62

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
