### PR TITLE
Add a favicon, make the info cards real links, and test the home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,18 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - Friendly themed `404` and `500` error pages within the standard chrome (#37).
 - GitHub Actions CI: lint, test, and build on pull requests and `main` (#27, #53).
 - Documentation set: `README`, `CONFIG.md`, `USER_GUIDE.md`, `CONTRIBUTING.md`, and this changelog (#39).
-- Component-render test coverage for `ProjectCard` and `Blurb` using React Testing Library + jsdom (#38), extended to the shared chrome — `TopBar`, `BottomBar`, `Seo`, and `ErrorPage` (#58) — and to the color-mode wiring in `_app` (#62).
+- Component-render test coverage for `ProjectCard` and `Blurb` using React Testing Library + jsdom (#38), extended to the shared chrome — `TopBar`, `BottomBar`, `Seo`, and `ErrorPage` (#58) — to the color-mode wiring in `_app` (#62), and to the home page's card ordering and `#projects` anchor (#64).
 - Node-based `Dockerfile`, `compose.yaml`, and dev container; CI switched to npm (#40).
 - `/legal` page covering the license, copyright, disclaimer, privacy (what is stored on the visitor's device), and third-party component notices (#21).
 - Footer copyright notice with a license link, plus **Home** and **Legal** navigation links; the copyright year is baked in at build time via `NEXT_PUBLIC_BUILD_YEAR` (#20).
 - Optional `websiteLink` field on a project, rendered as a **Visit Site** button beside the project card's GitHub button, and documented in `CONFIG.md` (#51, #56).
 - Live-site links for Barony, Roam, and microbiome, plus project cards for the sibling sites [danielstephenson.dev](https://danielstephenson.dev) and [dansplugins.com](https://dansplugins.com) (#51, #54).
+- A favicon: an SVG "P" mark in the brand blue that follows the OS light/dark preference (#67).
 
 ### Changed
 
 - The site now describes its projects as "source-available" rather than "open source", both in the home-page blurb and in the default page description (#49).
+- The home page's **Contribute** and **Explore the Code** cards are now real links rather than clickable panels, so they support open-in-new-tab, middle-click, and "copy link address", and they carry the same external-link icon as the site's other off-site links (#66).
 
 ### Fixed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -25,7 +25,7 @@ No special software is required to use the website — just a modern web browser
 1. Find the project's card on the home page.
 2. Click the **GitHub** button on the card to open its repository in a new tab.
 
-You can also reach the full GitHub organization via the **GitHub** link in the top navigation bar or **View on GitHub** in the hero.
+You can also reach the full GitHub organization via the **GitHub** link in the top navigation bar, **View on GitHub** in the hero, or the **Contribute** and **Explore the Code** cards in the *Get involved* row. All of these open in a new tab.
 
 ### Visiting a Project's Live Site
 

--- a/__tests__/Blurb.test.tsx
+++ b/__tests__/Blurb.test.tsx
@@ -3,13 +3,15 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import Blurb from '../components/Blurb';
 
+const ORG_URL = 'https://github.com/Preponderous-Software';
+
 describe('Blurb', () => {
     it('renders the hero heading and call-to-action links', () => {
         render(<Blurb />);
         expect(screen.getByRole('heading', { name: 'Preponderous Software' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /browse projects/i })).toBeInTheDocument();
         const github = screen.getByRole('link', { name: /view on github/i });
-        expect(github).toHaveAttribute('href', 'https://github.com/Preponderous-Software');
+        expect(github).toHaveAttribute('href', ORG_URL);
     });
 
     it('renders the three get-involved info cards', () => {
@@ -17,5 +19,22 @@ describe('Blurb', () => {
         expect(screen.getByText('Contribute')).toBeInTheDocument();
         expect(screen.getByText('Explore the Code')).toBeInTheDocument();
         expect(screen.getByText('Source Available')).toBeInTheDocument();
+    });
+
+    it('renders the linking info cards as real anchors that open in a new tab', () => {
+        render(<Blurb />);
+        for (const name of [/^contribute/i, /^explore the code/i]) {
+            const card = screen.getByRole('link', { name });
+            expect(card).toHaveAttribute('href', ORG_URL);
+            expect(card).toHaveAttribute('target', '_blank');
+            expect(card).toHaveAttribute('rel', 'noopener noreferrer');
+        }
+    });
+
+    it('leaves the non-linking info card as plain, unfocusable content', () => {
+        render(<Blurb />);
+        const card = screen.getByText('Source Available').closest('a');
+        expect(card).toBeNull();
+        expect(screen.queryByRole('link', { name: /source available/i })).not.toBeInTheDocument();
     });
 });

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import Home from '../pages/index';
+import projectData from '../pages/data/projects.json';
+import packageJson from '../package.json';
+import { type Project } from '../utils/projects';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/' }),
+}));
+
+const projects = projectData.projects as Project[];
+
+// Each card's only stable, class-free handle on which project it is showing is
+// its "GitHub" action, so read those in DOM order to recover the card order.
+const renderedTitlesInOrder = (section: HTMLElement): string[] => {
+    const byGithubLink = new Map(projects.map((p) => [p.githubLink, p.title]));
+    return within(section)
+        .getAllByRole('link', { name: 'GitHub' })
+        .map((link) => byGithubLink.get(link.getAttribute('href') ?? '') ?? '<unknown>');
+};
+
+describe('Home page', () => {
+    let container: HTMLElement;
+    let projectsSection: HTMLElement;
+
+    beforeEach(() => {
+        ({ container } = render(<Home/>));
+        projectsSection = container.querySelector('#projects') as HTMLElement;
+    });
+
+    it('gives the Projects section the #projects id the hero button scrolls to', () => {
+        // Blurb's "Browse Projects" button is href="#projects"; losing this id
+        // would silently turn that button into a no-op.
+        expect(projectsSection).not.toBeNull();
+        expect(within(projectsSection).getByText('Projects')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /browse projects/i })).toHaveAttribute('href', '#projects');
+    });
+
+    it('renders a card for every project in projects.json', () => {
+        expect(renderedTitlesInOrder(projectsSection).sort()).toEqual(
+            projects.map((p) => p.title).sort()
+        );
+    });
+
+    it('orders the cards alphabetically by title, case-insensitively', () => {
+        const titles = renderedTitlesInOrder(projectsSection);
+        const alphabetical = [...titles].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+        expect(titles).toEqual(alphabetical);
+    });
+
+    it('links each card that has one to the project\'s own site', () => {
+        const withSites = projects.filter((p) => p.websiteLink);
+        const visitLinks = within(projectsSection).getAllByRole('link', { name: 'Visit Site' });
+        expect(visitLinks.map((link) => link.getAttribute('href')).sort()).toEqual(
+            withSites.map((p) => p.websiteLink).sort()
+        );
+    });
+
+    it('shows the package.json version in the footer', () => {
+        expect(screen.getByText(`v${packageJson.version}`)).toBeInTheDocument();
+    });
+});

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -12,7 +12,9 @@ import {
     infoCardStyle,
     infoCardIconStyle,
     infoCardTitleStyle,
-    infoCardIconSizeStyle
+    infoCardIconSizeStyle,
+    infoCardLinkStyle,
+    infoCardExternalIconStyle
 } from '../styles/styles';
 
 const ORG_URL = 'https://github.com/Preponderous-Software';
@@ -22,42 +24,49 @@ const InfoCard: React.FC<{
     title: string;
     content: string;
     href?: string
-}> = ({icon, title, content, href}) => (
-    <Grid item xs={12} md={4}>
-        <Paper
-            elevation={0}
-            // When the card links somewhere, expose it as a focusable, keyboard-
-            // operable control: a mouse-only onClick left keyboard and screen-
-            // reader users unable to reach or activate these cards.
-            role={href ? 'link' : undefined}
-            tabIndex={href ? 0 : undefined}
-            sx={(theme) => ({
-                ...infoCardStyle(theme),
-                cursor: href ? 'pointer' : 'default',
-                '&:hover': href ? {
-                    transform: 'translateY(-2px)',
-                    boxShadow: '0 6px 20px rgba(0,0,0,0.12)',
-                    transition: 'transform 0.2s ease, box-shadow 0.2s ease'
-                } : {}
-            })}
-            onClick={() => href && window.open(href, '_blank', 'noopener,noreferrer')}
-            onKeyDown={(e) => {
-                if (href && (e.key === 'Enter' || e.key === ' ')) {
-                    e.preventDefault();
-                    window.open(href, '_blank', 'noopener,noreferrer');
-                }
-            }}
-        >
+}> = ({icon, title, content, href}) => {
+    const body = (
+        <>
             <Box sx={(theme) => infoCardIconStyle(theme)}>
                 {icon}
             </Box>
             <Typography variant="h6" gutterBottom sx={(theme) => infoCardTitleStyle()}>
                 {title}
+                {href ? <OpenInNewIcon sx={infoCardExternalIconStyle}/> : null}
             </Typography>
             <Typography variant="body1" color="text.secondary">{content}</Typography>
-        </Paper>
-    </Grid>
-);
+        </>
+    );
+
+    // A card that links somewhere is a real anchor rather than a div wired up
+    // with role="link" and a window.open handler: that keeps "open in new tab",
+    // middle-click, and "copy link address" working, and survives the popup
+    // blockers that would otherwise swallow window.open.
+    return (
+        <Grid item xs={12} md={4}>
+            {href ? (
+                <Paper
+                    elevation={0}
+                    component="a"
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={(theme) => ({...infoCardStyle(theme), ...infoCardLinkStyle})}
+                >
+                    {body}
+                </Paper>
+            ) : (
+                // Nothing to activate here, so no pointer and no hover lift.
+                <Paper
+                    elevation={0}
+                    sx={(theme) => ({...infoCardStyle(theme), cursor: 'default', '&:hover': {}})}
+                >
+                    {body}
+                </Paper>
+            )}
+        </Grid>
+    );
+};
 
 const Blurb: React.FC = () => (
     <Box sx={(theme) => blurbBoxStyle(theme)}>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,6 +7,11 @@ export default function Document() {
     return (
         <Html lang="en">
             <Head>
+                {/*
+                  Next 12 serves no icon of its own, so without this every page
+                  load 404s on /favicon.ico and the tab shows a placeholder.
+                */}
+                <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
                 <link rel="preconnect" href="https://fonts.googleapis.com"/>
                 <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous"/>
                 <link

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Preponderous Software">
+    <!--
+      A "P" mark in the site's primary blue. The glyph is drawn as a path rather
+      than set in Space Grotesk because favicons are rendered without the page's
+      webfonts, so a text element would fall back to whatever the browser has.
+      A favicon also cannot read the site's own color-mode state, so it follows
+      the OS scheme instead and shifts to the dark-theme blue there.
+    -->
+    <style>
+        .bg { fill: #4263eb; }
+        @media (prefers-color-scheme: dark) {
+            .bg { fill: #5c7cfa; }
+        }
+    </style>
+    <rect class="bg" width="64" height="64" rx="14"/>
+    <path
+        fill="#ffffff"
+        fill-rule="evenodd"
+        d="M19 14 H34 a11 11 0 0 1 0 22 H26 V50 H19 Z M26 21 H34 a4 4 0 0 1 0 8 H26 Z"
+    />
+</svg>

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -271,3 +271,24 @@ export const infoCardTitleStyle = () => ({
 export const infoCardIconSizeStyle = {
     fontSize: 40,
 };
+
+/**
+ * Extra styling for the linking variant of an info card. It renders as a real
+ * anchor, so the browser's default link colour and underline have to be undone
+ * to keep it looking like the non-linking card next to it.
+ */
+export const infoCardLinkStyle = {
+    textDecoration: 'none',
+    color: 'inherit',
+    cursor: 'pointer',
+};
+
+/**
+ * The external-link affordance on a linking info card, matching the
+ * OpenInNewIcon the top bar and hero already put on their outbound links.
+ */
+export const infoCardExternalIconStyle = {
+    fontSize: '1rem',
+    marginLeft: '0.35rem',
+    verticalAlign: 'middle',
+};


### PR DESCRIPTION
## Summary

- **Favicon (#67)** — `public/` had no icon and `_document.tsx` emitted no `<link rel="icon">`, so every page load 404'd on `/favicon.ico` and tabs/bookmarks showed a placeholder. Adds `public/favicon.svg`: a "P" mark drawn as a path (favicons render without the page's webfonts, so Space Grotesk isn't available) on a rounded square in the theme's primary blue, shifting to the dark-theme blue under `prefers-color-scheme: dark`.
- **Info cards are real links (#66)** — `Blurb`'s `InfoCard` bolted link behaviour onto a `Paper` (a `div`) with `role="link"`, `tabIndex`, `onClick`, and `onKeyDown` calling `window.open`. Now the linking variant renders as `Paper component="a" href target="_blank" rel="noopener noreferrer"`, restoring open-in-new-tab, middle-click, ctrl/cmd-click, and "copy link address", and surviving popup blockers. It also gains the `OpenInNewIcon` affordance that `TopBar`'s nav links and the hero's **View on GitHub** button already carry. The non-linking **Source Available** card stays a plain `Paper` with no pointer and no hover lift.
- **Home page test (#64)** — `pages/index.tsx` was the only page without a paired Vitest file. Adds `__tests__/index.test.tsx`.

## Notes

- Card order is asserted by reading the per-card **GitHub** link hrefs in DOM order and checking they're sorted case-insensitively — rather than re-running `sortProjectsByTitle` and comparing, which would be tautological.
- The non-linking card keeps its explicit `cursor: 'default'` so this change is visually neutral for it.
- `Blurb.test.tsx` now asserts `href`/`target`/`rel` on the two linking cards and that **Source Available** exposes no link role.

## Test plan

- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build`

(CI runs all three on this PR; this checkout has no local Node toolchain available, so CI is the verification gate.)

Closes #64
Closes #66
Closes #67

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
