### PR TITLE
Add client-side navigation and fix heading outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 ### Fixed
 
 - The light/dark toggle no longer stops working in browsers that block site data: reading and writing the saved preference is now guarded, so the mode still switches when it cannot be persisted (#61).
+- Internal navigation (Home, brand wordmark, footer **Home**/**Legal**, error page "Back to home") now does a client-side route transition via `next/link` instead of a full document reload (#71).
+- The heading outline is now contiguous on every page: the **Projects** section, "Get involved", and each card title use the correct heading level, and each error page's `<h1>` is its human-readable title rather than the status code (#72).
 
 ### Removed
 

--- a/__tests__/Blurb.test.tsx
+++ b/__tests__/Blurb.test.tsx
@@ -21,6 +21,14 @@ describe('Blurb', () => {
         expect(screen.getByText('Source Available')).toBeInTheDocument();
     });
 
+    it('gives "Get involved" a heading level 2 and each info-card title a heading level 3', () => {
+        render(<Blurb />);
+        expect(screen.getByRole('heading', { level: 2, name: 'Get involved' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 3, name: 'Contribute' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 3, name: 'Explore the Code' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 3, name: 'Source Available' })).toBeInTheDocument();
+    });
+
     it('renders the linking info cards as real anchors that open in a new tab', () => {
         render(<Blurb />);
         for (const name of [/^contribute/i, /^explore the code/i]) {

--- a/__tests__/ErrorPage.test.tsx
+++ b/__tests__/ErrorPage.test.tsx
@@ -21,11 +21,16 @@ describe('ErrorPage', () => {
     });
 
     it('renders the code, title, and message it was given', () => {
-        expect(screen.getByRole('heading', { level: 1, name: '404' })).toBeInTheDocument();
-        expect(screen.getByRole('heading', { level: 4, name: 'Page not found' })).toBeInTheDocument();
+        expect(screen.getByText('404')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 1, name: 'Page not found' })).toBeInTheDocument();
         expect(
             screen.getByText('We could not find the page you were looking for.')
         ).toBeInTheDocument();
+    });
+
+    it('makes the human-readable title the page\'s only heading level 1', () => {
+        expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+        expect(screen.queryByRole('heading', { level: 1, name: '404' })).not.toBeInTheDocument();
     });
 
     it('offers a way back to the home page', () => {

--- a/__tests__/ProjectCard.test.tsx
+++ b/__tests__/ProjectCard.test.tsx
@@ -13,7 +13,7 @@ describe('ProjectCard', () => {
                 technology="Java"
             />
         );
-        expect(screen.getByText('Viron')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 3, name: 'Viron' })).toBeInTheDocument();
         expect(screen.getByText('A flexible simulation framework.')).toBeInTheDocument();
         expect(screen.getByText('Java')).toBeInTheDocument();
     });

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -36,7 +36,7 @@ describe('Home page', () => {
         // Blurb's "Browse Projects" button is href="#projects"; losing this id
         // would silently turn that button into a no-op.
         expect(projectsSection).not.toBeNull();
-        expect(within(projectsSection).getByText('Projects')).toBeInTheDocument();
+        expect(within(projectsSection).getByRole('heading', { level: 2, name: 'Projects' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /browse projects/i })).toHaveAttribute('href', '#projects');
     });
 

--- a/components/Blurb.tsx
+++ b/components/Blurb.tsx
@@ -30,7 +30,7 @@ const InfoCard: React.FC<{
             <Box sx={(theme) => infoCardIconStyle(theme)}>
                 {icon}
             </Box>
-            <Typography variant="h6" gutterBottom sx={(theme) => infoCardTitleStyle()}>
+            <Typography variant="h6" component="h3" gutterBottom sx={(theme) => infoCardTitleStyle()}>
                 {title}
                 {href ? <OpenInNewIcon sx={infoCardExternalIconStyle}/> : null}
             </Typography>
@@ -111,6 +111,7 @@ const Blurb: React.FC = () => (
 
         <Typography
             variant="overline"
+            component="h2"
             color="text.secondary"
             sx={{display: 'block', textAlign: 'center', letterSpacing: '0.1em'}}
         >

--- a/components/BottomBar.tsx
+++ b/components/BottomBar.tsx
@@ -1,4 +1,5 @@
 import {AppBar, Box, Button, Link, Toolbar, Typography, useTheme} from '@mui/material';
+import NextLink from 'next/link';
 import React, {useContext} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
@@ -25,7 +26,7 @@ const FooterButton: React.FC<{ href: string; icon: React.ReactNode; children: Re
     children,
 }) => {
     const isExternal = href.startsWith('http');
-    return (
+    const button = (
         <Button
             color="inherit"
             href={href}
@@ -36,6 +37,15 @@ const FooterButton: React.FC<{ href: string; icon: React.ReactNode; children: Re
         >
             {children}
         </Button>
+    );
+
+    // Internal routes go through next/link so navigation is a client-side
+    // transition rather than a full document reload; external links stay plain
+    // anchors (they leave the app anyway).
+    return isExternal ? button : (
+        <NextLink href={href} passHref>
+            {button}
+        </NextLink>
     );
 };
 
@@ -51,9 +61,11 @@ const CopyrightNotice: React.FC = () => (
     <Typography variant="body2" color="inherit" component="div" sx={{opacity: 0.85}}>
         {formatCopyright()}
         {' · '}
-        <Link href="/legal" color="inherit" underline="always">
-            {LICENSE_SHORT_NAME}
-        </Link>
+        <NextLink href="/legal" passHref>
+            <Link color="inherit" underline="always">
+                {LICENSE_SHORT_NAME}
+            </Link>
+        </NextLink>
     </Typography>
 );
 

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Box, Button, Container, Typography} from '@mui/material';
 import HomeIcon from '@mui/icons-material/Home';
+import NextLink from 'next/link';
 import TopBar from './TopBar';
 import Seo from './Seo';
 import BottomBar from './BottomBar';
@@ -19,18 +20,20 @@ const ErrorPage: React.FC<{code: string; title: string; message: string}> = ({co
         <Seo title={`${code} — ${title}`} description={message}/>
         <TopBar/>
         <Container component="main" id="main" maxWidth="sm" sx={{py: 8, textAlign: 'center', flexGrow: 1}}>
-            <Typography variant="h1" color="primary" sx={{fontWeight: 700}}>
+            <Typography variant="h1" component="p" color="primary" sx={{fontWeight: 700}}>
                 {code}
             </Typography>
-            <Typography variant="h4" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            <Typography variant="h4" component="h1" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
                 {title}
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{mb: 3}}>
                 {message}
             </Typography>
-            <Button variant="contained" startIcon={<HomeIcon/>} href="/">
-                Back to home
-            </Button>
+            <NextLink href="/" passHref>
+                <Button variant="contained" startIcon={<HomeIcon/>}>
+                    Back to home
+                </Button>
+            </NextLink>
         </Container>
         <BottomBar version={version}/>
     </Box>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -50,7 +50,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink
                     >
                         {title.charAt(0).toUpperCase()}
                     </Avatar>
-                    <Typography variant="h6" component="div" sx={{fontWeight: 600, lineHeight: 1.2}}>
+                    <Typography variant="h6" component="h3" sx={{fontWeight: 600, lineHeight: 1.2}}>
                         {title}
                     </Typography>
                 </Stack>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,6 +1,7 @@
 import {AppBar, Box, Button, Link, Toolbar, Typography, useTheme} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {useRouter} from 'next/router';
+import NextLink from 'next/link';
 import React, {useContext} from 'react';
 import {ColorModeToggleSwitch} from './ColorModeToggleSwitch';
 import {ColorModeContext} from '../utils/ColorModeContext';
@@ -20,7 +21,7 @@ import {
 // visually distinguishable from the in-site navigation they sit beside.
 const NavButton: React.FC<{ href: string; active?: boolean; children: React.ReactNode }> = ({href, active = false, children}) => {
     const isExternal = href.startsWith('http');
-    return (
+    const button = (
         <Button
             color="inherit"
             href={href}
@@ -42,21 +43,31 @@ const NavButton: React.FC<{ href: string; active?: boolean; children: React.Reac
             {children}
         </Button>
     );
+
+    // Internal routes go through next/link so navigation is a client-side
+    // transition rather than a full document reload; external links stay plain
+    // anchors (they leave the app anyway).
+    return isExternal ? button : (
+        <NextLink href={href} passHref>
+            {button}
+        </NextLink>
+    );
 };
 
 const BrandName: React.FC = () => (
     // The wordmark links home — the near-universal "click the logo to return to
     // the home page" convention.
-    <Link
-        href="/"
-        underline="none"
-        color="inherit"
-        sx={(theme) => ({...brandNameStyle(theme), display: 'inline-block'})}
-    >
-        <Typography variant="h6" color="inherit" component="span">
-            Preponderous Software
-        </Typography>
-    </Link>
+    <NextLink href="/" passHref>
+        <Link
+            underline="none"
+            color="inherit"
+            sx={(theme) => ({...brandNameStyle(theme), display: 'inline-block'})}
+        >
+            <Typography variant="h6" color="inherit" component="span">
+                Preponderous Software
+            </Typography>
+        </Link>
+    </NextLink>
 );
 
 const TopBar: React.FC = () => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,8 +30,8 @@ const SectionDivider: React.FC = () => (
 )
 
 const ProjectsSection: React.FC<{projects: Project[]}> = ({projects}) => (
-    <Box id="projects" sx={projectsBoxStyle}>
-        <Typography variant="h3" component="div" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+    <Box id="projects" component="section" aria-labelledby="projects-heading" sx={projectsBoxStyle}>
+        <Typography id="projects-heading" variant="h3" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
             Projects
         </Typography>
         <Grid container {...gridContainerStyle}>

--- a/utils/colorMode.ts
+++ b/utils/colorMode.ts
@@ -1,7 +1,7 @@
 export type ColorMode = 'light' | 'dark';
 
 // localStorage key under which the user's explicit color-mode choice is saved,
-// so the selection survives navigation (full page loads) and return visits.
+// so the selection survives page reloads and return visits.
 export const COLOR_MODE_STORAGE_KEY = 'preponderous-color-mode';
 
 const isColorMode = (value: string | null): value is ColorMode =>


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- Wraps internal links (Home, brand wordmark, footer Home/Legal, error page "Back to home") in `next/link` so clicking them does a client-side route transition instead of a full document reload/re-fetch. External links (GitHub, Source Code, Report a Bug) are untouched — they stay plain anchors with `target="_blank"`/`rel="noopener noreferrer"`.
- Fixes the site's heading outline so it is contiguous and each page has exactly one meaningful `<h1>`:
  - `pages/index.tsx` — the **Projects** section header becomes an `<h2>` (was a `<div>`) and its `<Box>` becomes a labelled `<section>` landmark.
  - `components/Blurb.tsx` — "Get involved" becomes an `<h2>`; the three info-card titles become `<h3>` (were `<h6>`, skipping four levels under the page's `<h1>`).
  - `components/ProjectCard.tsx` — the project title becomes an `<h3>` (was a `<div>`), sitting under the Projects `<h2>`.
  - `components/ErrorPage.tsx` — the status code (`404`/`500`) is now purely visual (`component="p"`); the human-readable title ("Page not found" / "Something went wrong") is the page's `<h1>`.
- Updates a stale comment in `utils/colorMode.ts` that attributed persistence to surviving "full page loads" — no longer accurate now that internal navigation is client-side.

Visual appearance is unchanged in all cases — only the rendered element (`component`) or wrapping (`next/link`) changed.

## Scope note

Issue #73 (dark-mode flash before hydration) was intentionally left out of this PR — the issue itself asks for it to be done on its own since it touches `_document.tsx`/`_app.tsx`'s SSR/hydration contract, separately from this PR's `next/link`/heading changes.

## Verification note

This sandbox has no Node/npm available (`npm ci` requires approval that cannot be granted non-interactively here), so `lint`/`test`/`build` could not be run locally. All changes were verified by reading source and tests; CI (`npm ci` → `lint` → `test` → `build`) on this PR is the actual verification anchor — do not merge until it is green.

## Test plan

- [ ] CI (`npm ci`, `npm run lint`, `npm test`, `npm run build`) passes on this PR
- [x] Updated `__tests__/index.test.tsx`, `__tests__/Blurb.test.tsx`, `__tests__/ProjectCard.test.tsx`, `__tests__/ErrorPage.test.tsx` to assert heading role/level per the new outline
- [x] Existing `TopBar`/`BottomBar`/`ErrorPage` link assertions (href, target, rel, aria-current) still hold with the `next/link` wrapping

Closes #71
Closes #72

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
