### PR TITLE
Add /about and /contact pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - A favicon: an SVG "P" mark in the brand blue that follows the OS light/dark preference (#67).
 - A PNG favicon and apple-touch-icon fallback (rendered from the SVG mark) so Safari and "Add to Home Screen" no longer show a placeholder (#69).
 - `Seo` now emits a canonical `<link>`, `og:url`, and an `og:image`/`twitter:image` (with `twitter:card` upgraded to `summary_large_image`), documented in `CONFIG.md` (#65).
+- `/about` page covering the mission, values, and who runs Preponderous Software, and `/contact` page covering how to reach out (report a bug, or a project's own repository); both linked from the top navigation bar (#18, #19).
 
 ### Changed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -49,6 +49,11 @@ Cards without a **Visit Site** button have no hosted version — use the **GitHu
 2. The **/legal** page covers the license the projects are published under, the copyright and disclaimer, what the site stores on your device (only your light/dark preference), and the third-party components the site is built with.
 3. Links to the full license text open in a new tab.
 
+### Learning About Preponderous Software
+
+1. Click **About** in the top navigation bar.
+2. The **/about** page covers the mission, values, and who runs Preponderous Software, with links to the **Legal** and **Contact** pages for more detail.
+
 ### Reporting a Website Bug
 
 If you find a bug on the website itself:
@@ -57,4 +62,4 @@ If you find a bug on the website itself:
 2. Click **New Issue**.
 3. Describe the problem and include steps to reproduce it.
 
-You can also use the **Report a Bug** link in the footer.
+You can also use the **Report a Bug** link in the footer, or visit the **/contact** page (reachable via **Contact** in the top navigation bar) for the same link plus where to go for project-specific questions.

--- a/__tests__/TopBar.test.tsx
+++ b/__tests__/TopBar.test.tsx
@@ -24,12 +24,14 @@ describe('TopBar', () => {
         expect(screen.getByRole('link', { name: 'Preponderous Software' })).toHaveAttribute('href', '/');
     });
 
-    it('keeps the internal nav link in the same tab', () => {
+    it('keeps internal nav links in the same tab', () => {
         render(<TopBar/>);
-        const home = screen.getByRole('link', { name: 'Home' });
-        expect(home).toHaveAttribute('href', '/');
-        expect(home).not.toHaveAttribute('target');
-        expect(home).not.toHaveAttribute('rel');
+        for (const [name, href] of [['Home', '/'], ['About', '/about'], ['Contact', '/contact']] as const) {
+            const link = screen.getByRole('link', { name });
+            expect(link).toHaveAttribute('href', href);
+            expect(link).not.toHaveAttribute('target');
+            expect(link).not.toHaveAttribute('rel');
+        }
     });
 
     it('opens the external nav link in a new tab with rel="noopener noreferrer"', () => {
@@ -49,7 +51,15 @@ describe('TopBar', () => {
         router.pathname = '/legal';
         render(<TopBar/>);
         expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current');
+        expect(screen.getByRole('link', { name: 'About' })).not.toHaveAttribute('aria-current');
+        expect(screen.getByRole('link', { name: 'Contact' })).not.toHaveAttribute('aria-current');
         expect(screen.getByRole('link', { name: 'GitHub' })).not.toHaveAttribute('aria-current');
+    });
+
+    it('marks the About link as current on the About page', () => {
+        router.pathname = '/about';
+        render(<TopBar/>);
+        expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute('aria-current', 'page');
     });
 
     it('leaves the color-mode toggle unchecked in light mode', () => {

--- a/__tests__/about.test.tsx
+++ b/__tests__/about.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AboutPage from '../pages/about';
+import { COPYRIGHT_HOLDER } from '../utils/copyright';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/about' }),
+}));
+
+describe('About page', () => {
+    beforeEach(() => {
+        render(<AboutPage/>);
+    });
+
+    it('renders an About heading and the mission/values/team sections', () => {
+        expect(screen.getByRole('heading', { level: 1, name: 'About' })).toBeInTheDocument();
+        for (const title of ['Mission', 'Values', 'Team', 'Get Involved']) {
+            expect(screen.getByRole('heading', { level: 2, name: title })).toBeInTheDocument();
+        }
+    });
+
+    it('names who runs Preponderous Software', () => {
+        expect(screen.getByText(new RegExp(COPYRIGHT_HOLDER))).toBeInTheDocument();
+    });
+
+    it('links to the Legal page for license and privacy details, in the same tab', () => {
+        const links = screen.getAllByRole('link', { name: 'Legal' });
+        expect(links.length).toBeGreaterThan(0);
+        for (const link of links) {
+            expect(link).toHaveAttribute('href', '/legal');
+            expect(link).not.toHaveAttribute('target');
+            expect(link).not.toHaveAttribute('rel');
+        }
+    });
+
+    it('links to the Contact page to reach out, in the same tab', () => {
+        // TopBar's own "Contact" nav button also matches by name, so there are two.
+        const links = screen.getAllByRole('link', { name: 'Contact' });
+        expect(links.length).toBeGreaterThan(0);
+        for (const link of links) {
+            expect(link).toHaveAttribute('href', '/contact');
+            expect(link).not.toHaveAttribute('target');
+            expect(link).not.toHaveAttribute('rel');
+        }
+    });
+
+    it('opens the GitHub organization link in a new tab', () => {
+        // TopBar's own "GitHub" nav button also matches by name, so there are two.
+        const links = screen.getAllByRole('link', { name: 'GitHub' });
+        expect(links.length).toBeGreaterThan(0);
+        for (const link of links) {
+            expect(link).toHaveAttribute('href', 'https://github.com/Preponderous-Software');
+            expect(link).toHaveAttribute('target', '_blank');
+            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        }
+    });
+});

--- a/__tests__/about.test.tsx
+++ b/__tests__/about.test.tsx
@@ -23,7 +23,8 @@ describe('About page', () => {
     });
 
     it('names who runs Preponderous Software', () => {
-        expect(screen.getByText(new RegExp(COPYRIGHT_HOLDER))).toBeInTheDocument();
+        // The footer's copyright notice also names the same holder.
+        expect(screen.getAllByText(new RegExp(COPYRIGHT_HOLDER)).length).toBeGreaterThan(0);
     });
 
     it('links to the Legal page for license and privacy details, in the same tab', () => {

--- a/__tests__/contact.test.tsx
+++ b/__tests__/contact.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ContactPage from '../pages/contact';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/contact' }),
+}));
+
+describe('Contact page', () => {
+    beforeEach(() => {
+        render(<ContactPage/>);
+    });
+
+    it('renders a Contact heading and the report/project sections', () => {
+        expect(screen.getByRole('heading', { level: 1, name: 'Contact' })).toBeInTheDocument();
+        for (const title of ['Report a Bug', 'Projects']) {
+            expect(screen.getByRole('heading', { level: 2, name: title })).toBeInTheDocument();
+        }
+    });
+
+    it('links to filing a new bug report on the website repository', () => {
+        const link = screen.getByRole('link', { name: /report a website bug/i });
+        expect(link).toHaveAttribute(
+            'href',
+            'https://github.com/Preponderous-Software/preponderous-dot-org/issues/new'
+        );
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('links to the GitHub organization for project-specific contact', () => {
+        const link = screen.getByRole('link', { name: /preponderous software on github/i });
+        expect(link).toHaveAttribute('href', 'https://github.com/Preponderous-Software');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+});

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -86,6 +86,8 @@ const TopBar: React.FC = () => {
 
                     <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
                         <NavButton href="/" active={isActiveNavLink(pathname, '/')}>Home</NavButton>
+                        <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>
+                        <NavButton href="/contact" active={isActiveNavLink(pathname, '/contact')}>Contact</NavButton>
                         <NavButton href="https://github.com/Preponderous-Software">GitHub</NavButton>
                     </Box>
                 </Box>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,119 @@
+import type {NextPage} from 'next';
+import {Box, Container, Link, List, ListItem, Typography} from '@mui/material';
+import NextLink from 'next/link';
+import React from 'react';
+import TopBar from '../components/TopBar';
+import BottomBar from '../components/BottomBar';
+import Seo from '../components/Seo';
+import {COPYRIGHT_HOLDER} from '../utils/copyright';
+import {pageStyle, sectionHeaderStyle, sectionDividerStyle} from '../styles/styles';
+
+// pull the displayed version from package.json so the footer stays in sync
+const version = require('../package.json').version;
+
+const ORG_URL = 'https://github.com/Preponderous-Software';
+
+// Internal routes navigate via next/link so they get a client-side transition
+// rather than a full reload, matching TopBar/BottomBar's NavButton/FooterButton.
+const InternalLink: React.FC<{href: string; children: React.ReactNode}> = ({href, children}) => (
+    <NextLink href={href} passHref>
+        <Link>{children}</Link>
+    </NextLink>
+);
+
+const AboutSection: React.FC<{title: string; children: React.ReactNode}> = ({title, children}) => (
+    <Box component="section" sx={{mb: 5}}>
+        <Typography variant="h5" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            {title}
+        </Typography>
+        {children}
+    </Box>
+);
+
+const Paragraph: React.FC<{children: React.ReactNode}> = ({children}) => (
+    <Typography variant="body1" color="text.secondary" sx={{mb: 2}}>
+        {children}
+    </Typography>
+);
+
+const AboutPage: NextPage = () => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo
+            title="About"
+            description="The mission, values, and team behind Preponderous Software."
+            path="/about"
+        />
+        <TopBar/>
+        <Container component="main" id="main" maxWidth="md" sx={{py: 4, flexGrow: 1}}>
+            <Typography variant="h3" component="h1" gutterBottom sx={{fontWeight: 700, letterSpacing: '-0.01em'}}>
+                About
+            </Typography>
+            <Paragraph>
+                Free, source-available games and assets — built in the open, and easy to run,
+                extend, and contribute to.
+            </Paragraph>
+            <Box sx={(theme) => sectionDividerStyle(theme)}/>
+
+            <AboutSection title="Mission">
+                <Paragraph>
+                    Preponderous Software makes games, simulations, and libraries, and publishes
+                    their source alongside them, so anyone can run, study, extend, or self-host
+                    what we build.
+                </Paragraph>
+            </AboutSection>
+
+            <AboutSection title="Values">
+                <List dense disablePadding>
+                    <ListItem disableGutters sx={{display: 'block'}}>
+                        <Typography variant="subtitle1" component="h3" sx={{fontWeight: 600}}>
+                            Source Available
+                        </Typography>
+                        <Paragraph>
+                            Everything we make is free to use, modify, and self-host for
+                            non-commercial purposes. See the <InternalLink href="/legal">Legal</InternalLink> page
+                            for the license that governs it.
+                        </Paragraph>
+                    </ListItem>
+                    <ListItem disableGutters sx={{display: 'block'}}>
+                        <Typography variant="subtitle1" component="h3" sx={{fontWeight: 600}}>
+                            Built in the Open
+                        </Typography>
+                        <Paragraph>
+                            Development happens on GitHub, where issues and pull requests are
+                            welcome on every project.
+                        </Paragraph>
+                    </ListItem>
+                    <ListItem disableGutters sx={{display: 'block'}}>
+                        <Typography variant="subtitle1" component="h3" sx={{fontWeight: 600}}>
+                            No Accounts, No Tracking
+                        </Typography>
+                        <Paragraph>
+                            This website has no accounts, no advertising, and no analytics. See
+                            the Privacy section of the <InternalLink href="/legal">Legal</InternalLink> page
+                            for details.
+                        </Paragraph>
+                    </ListItem>
+                </List>
+            </AboutSection>
+
+            <AboutSection title="Team">
+                <Paragraph>
+                    Preponderous Software is run by {COPYRIGHT_HOLDER}.
+                </Paragraph>
+            </AboutSection>
+
+            <AboutSection title="Get Involved">
+                <Paragraph>
+                    Browse the projects and their source on{' '}
+                    <Link href={ORG_URL} target="_blank" rel="noopener noreferrer">
+                        GitHub
+                    </Link>
+                    , or head to the <InternalLink href="/contact">Contact</InternalLink> page to reach out.
+                </Paragraph>
+            </AboutSection>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default AboutPage;

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,80 @@
+import type {NextPage} from 'next';
+import {Box, Container, Link, List, ListItem, Typography} from '@mui/material';
+import React from 'react';
+import TopBar from '../components/TopBar';
+import BottomBar from '../components/BottomBar';
+import Seo from '../components/Seo';
+import {pageStyle, sectionHeaderStyle, sectionDividerStyle} from '../styles/styles';
+
+// pull the displayed version from package.json so the footer stays in sync
+const version = require('../package.json').version;
+
+const ORG_URL = 'https://github.com/Preponderous-Software';
+const WEBSITE_REPO_URL = 'https://github.com/Preponderous-Software/preponderous-dot-org';
+
+const ContactSection: React.FC<{title: string; children: React.ReactNode}> = ({title, children}) => (
+    <Box component="section" sx={{mb: 5}}>
+        <Typography variant="h5" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            {title}
+        </Typography>
+        {children}
+    </Box>
+);
+
+const Paragraph: React.FC<{children: React.ReactNode}> = ({children}) => (
+    <Typography variant="body1" color="text.secondary" sx={{mb: 2}}>
+        {children}
+    </Typography>
+);
+
+const ContactPage: NextPage = () => (
+    <Box sx={(theme) => pageStyle(theme)}>
+        <Seo
+            title="Contact"
+            description="How to reach Preponderous Software: report a bug, open an issue, or find a project on GitHub."
+            path="/contact"
+        />
+        <TopBar/>
+        <Container component="main" id="main" maxWidth="md" sx={{py: 4, flexGrow: 1}}>
+            <Typography variant="h3" component="h1" gutterBottom sx={{fontWeight: 700, letterSpacing: '-0.01em'}}>
+                Contact
+            </Typography>
+            <Paragraph>
+                Preponderous Software doesn&apos;t run accounts, forums, or a support inbox — every
+                conversation happens in the open on GitHub.
+            </Paragraph>
+            <Box sx={(theme) => sectionDividerStyle(theme)}/>
+
+            <ContactSection title="Report a Bug">
+                <Paragraph>
+                    Found a problem with this website? File a report and include steps to
+                    reproduce it.
+                </Paragraph>
+                <List dense disablePadding>
+                    <ListItem disableGutters>
+                        <Link href={`${WEBSITE_REPO_URL}/issues/new`} target="_blank" rel="noopener noreferrer">
+                            Report a website bug
+                        </Link>
+                    </ListItem>
+                </List>
+            </ContactSection>
+
+            <ContactSection title="Projects">
+                <Paragraph>
+                    Each project has its own repository — open an issue or pull request directly
+                    on the project you&apos;re asking about.
+                </Paragraph>
+                <List dense disablePadding>
+                    <ListItem disableGutters>
+                        <Link href={ORG_URL} target="_blank" rel="noopener noreferrer">
+                            Preponderous Software on GitHub
+                        </Link>
+                    </ListItem>
+                </List>
+            </ContactSection>
+        </Container>
+        <BottomBar version={version}/>
+    </Box>
+);
+
+export default ContactPage;


### PR DESCRIPTION
## Summary

- Adds `/about`: mission, values, and who runs Preponderous Software, grounded in copy already used sitewide (the home page's tagline/value pillars, `utils/copyright.ts`'s `COPYRIGHT_HOLDER`) rather than inventing new marketing copy.
- Adds `/contact`: the project's only real contact channels — filing a website bug report, and each project's own GitHub repository. No email or social links are shown, since none exist anywhere in this repo's docs/config to source from.
- Both pages follow the `/legal` page's structure (`Seo`, `TopBar`/`BottomBar`, a titled-section layout) and are linked from the top navigation bar (`About`, `Contact`), matching the active-link/external-link conventions already used there.
- Updates `USER_GUIDE.md` and `CHANGELOG.md` to reflect the new pages.

Closes #18
Closes #19

**Skipped this cycle** (recorded per triage convention):
- #17 (dynamic `/projects` route with categorization/status indicators) — a larger, separate feature; batching it with #18/#19 would blow the scope ceiling and isn't a natural complement to two static content pages.
- #28 (staging environment on Fly.io) — requires external hosting-account/credentials setup this agent has no access to; needs a human to provision.

## Test plan

- [ ] CI (`npm ci` → `lint` → `test` → `build`) green on this PR — **could not be run locally**: this sandbox has no Linux Node/npm (only a Windows `npm` under `/mnt/c` that fails on the WSL UNC path), so local verification is **UNVERIFIED**. This PR touches source files the anchor validates, so please treat GitHub Actions CI on this PR's head commit as the authoritative check before merging.
- [x] Manually reviewed both new pages against sibling conventions (`pages/legal.tsx`, `components/BottomBar.tsx`, `components/TopBar.tsx`) for internal-link handling (`next/link` + `passHref`), external-link `target`/`rel`, and heading structure.
- [x] New tests added: `__tests__/about.test.tsx`, `__tests__/contact.test.tsx`; `__tests__/TopBar.test.tsx` updated for the two new nav links.

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
