### PR TITLE
Add dynamic /projects route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - A PNG favicon and apple-touch-icon fallback (rendered from the SVG mark) so Safari and "Add to Home Screen" no longer show a placeholder (#69).
 - `Seo` now emits a canonical `<link>`, `og:url`, and an `og:image`/`twitter:image` (with `twitter:card` upgraded to `summary_large_image`), documented in `CONFIG.md` (#65).
 - `/about` page covering the mission, values, and who runs Preponderous Software, and `/contact` page covering how to reach out (report a bug, or a project's own repository); both linked from the top navigation bar (#18, #19).
+- `/projects` page listing every showcased project grouped by category, plus an optional `status` chip (e.g. `Active`, `Maintenance`) on `ProjectCard`; both driven by new optional `category`/`status` fields on `pages/data/projects.json` entries, documented in `CONFIG.md` (#17).
 
 ### Changed
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -15,7 +15,7 @@ One value is injected automatically by `next.config.js` and does not need to be 
 
 ## Project Showcase Data
 
-The list of projects shown on the home page is data-driven, not hard-coded. It lives in:
+The list of projects shown on the home page and the `/projects` page is data-driven, not hard-coded. It lives in:
 
 ```
 pages/data/projects.json
@@ -31,8 +31,10 @@ The file contains a single `projects` array. Each entry supports these fields:
 | `githubLink` | yes | URL to the project's source repository (opens in a new tab). |
 | `technology` | yes | Primary language/technology, shown as a chip (e.g. `Python`, `Java`, `C++`). |
 | `websiteLink` | no | URL to a live/hosted version of the project. When set, the card shows a "Visit Site" button as its primary action, opening in a new tab. |
+| `category` | no | Grouping shown as a section heading on the `/projects` page (e.g. `Games`, `Simulations`, `Libraries`, `Tools`, `Websites`). Entries with no `category` are filed under "Other" (see `groupProjectsByCategory` in `utils/projects.ts`); they still appear on the home page either way. |
+| `status` | no | Maintenance state shown as a colour-coded chip on the card (e.g. `Active`, `Maintenance`). Any other value renders as a plain outlined chip. Omit it to show no status chip. |
 
-Projects are sorted alphabetically by title at render time (see `utils/projects.ts`), so entries may be listed in any order.
+Projects are sorted alphabetically by title at render time (see `utils/projects.ts`), so entries may be listed in any order. The home page lists every project in one flat, alphabetical grid; `/projects` groups the same data by `category`, each category's projects sorted alphabetically within it.
 
 **Example entry:**
 
@@ -43,7 +45,9 @@ Projects are sorted alphabetically by title at render time (see `utils/projects.
   "description": "Explore a procedurally-generated 2D world and interact with your surroundings.",
   "githubLink": "https://github.com/Preponderous-Software/Roam",
   "technology": "Python",
-  "websiteLink": "https://roam.preponderous.org"
+  "websiteLink": "https://roam.preponderous.org",
+  "category": "Games",
+  "status": "Active"
 }
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -18,7 +18,13 @@ No special software is required to use the website — just a modern web browser
 
 1. Open the home page.
 2. Scroll to the **Projects** section, or click **Browse Projects** in the hero.
-3. Each card shows the project's name, a short description, and its primary technology, along with a **GitHub** button and — for projects with a live version — a **Visit Site** button.
+3. Each card shows the project's name, a short description, its primary technology, and — where set — a maintenance status (e.g. **Active**, **Maintenance**), along with a **GitHub** button and — for projects with a live version — a **Visit Site** button.
+
+### Browsing Projects by Category
+
+1. Click **Projects** in the top navigation bar.
+2. The **/projects** page lists the same projects as the home page, grouped under category headings (e.g. **Games**, **Simulations**, **Libraries**).
+3. Each card behaves the same as on the home page — the same **GitHub**/**Visit Site** buttons and status chip.
 
 ### Opening a Project's Source Code
 

--- a/__tests__/ProjectCard.test.tsx
+++ b/__tests__/ProjectCard.test.tsx
@@ -45,6 +45,32 @@ describe('ProjectCard', () => {
         expect(screen.queryByRole('link', { name: /visit site/i })).toBeNull();
     });
 
+    it('omits the status chip when no status is given', () => {
+        render(
+            <ProjectCard
+                title="Roam"
+                description="Explore a procedurally-generated 2D world."
+                githubLink="https://github.com/Preponderous-Software/Roam"
+                technology="Python"
+            />
+        );
+        expect(screen.queryByText('Active')).toBeNull();
+        expect(screen.queryByText('Maintenance')).toBeNull();
+    });
+
+    it('renders a status chip when status is given', () => {
+        render(
+            <ProjectCard
+                title="Roam"
+                description="Explore a procedurally-generated 2D world."
+                githubLink="https://github.com/Preponderous-Software/Roam"
+                technology="Python"
+                status="Active"
+            />
+        );
+        expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
     it('renders a Visit Site button linking to the live site in a new tab when websiteLink is set', () => {
         render(
             <ProjectCard

--- a/__tests__/TopBar.test.tsx
+++ b/__tests__/TopBar.test.tsx
@@ -26,7 +26,7 @@ describe('TopBar', () => {
 
     it('keeps internal nav links in the same tab', () => {
         render(<TopBar/>);
-        for (const [name, href] of [['Home', '/'], ['About', '/about'], ['Contact', '/contact']] as const) {
+        for (const [name, href] of [['Home', '/'], ['Projects', '/projects'], ['About', '/about'], ['Contact', '/contact']] as const) {
             const link = screen.getByRole('link', { name });
             expect(link).toHaveAttribute('href', href);
             expect(link).not.toHaveAttribute('target');
@@ -51,6 +51,7 @@ describe('TopBar', () => {
         router.pathname = '/legal';
         render(<TopBar/>);
         expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current');
+        expect(screen.getByRole('link', { name: 'Projects' })).not.toHaveAttribute('aria-current');
         expect(screen.getByRole('link', { name: 'About' })).not.toHaveAttribute('aria-current');
         expect(screen.getByRole('link', { name: 'Contact' })).not.toHaveAttribute('aria-current');
         expect(screen.getByRole('link', { name: 'GitHub' })).not.toHaveAttribute('aria-current');
@@ -60,6 +61,12 @@ describe('TopBar', () => {
         router.pathname = '/about';
         render(<TopBar/>);
         expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('marks the Projects link as current on the Projects page', () => {
+        router.pathname = '/projects';
+        render(<TopBar/>);
+        expect(screen.getByRole('link', { name: 'Projects' })).toHaveAttribute('aria-current', 'page');
     });
 
     it('leaves the color-mode toggle unchecked in light mode', () => {

--- a/__tests__/projects.test.ts
+++ b/__tests__/projects.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { sortProjectsByTitle, type Project } from '../utils/projects';
+import { groupProjectsByCategory, sortProjectsByTitle, type Project } from '../utils/projects';
 
-const make = (title: string): Project => ({
+const make = (title: string, category?: string): Project => ({
     id: title.toLowerCase(),
     title,
     description: '',
     githubLink: '',
     technology: '',
+    category,
 });
 
 describe('sortProjectsByTitle', () => {
@@ -24,5 +25,51 @@ describe('sortProjectsByTitle', () => {
 
     it('returns an empty array unchanged', () => {
         expect(sortProjectsByTitle([])).toEqual([]);
+    });
+});
+
+describe('groupProjectsByCategory', () => {
+    it('groups projects under their category', () => {
+        const groups = groupProjectsByCategory([
+            make('Barony', 'Games'),
+            make('Viron', 'Libraries'),
+            make('Roam', 'Games'),
+        ]);
+        expect(groups.map((g) => g.category)).toEqual(['Games', 'Libraries']);
+        expect(groups[0].projects.map((p) => p.title)).toEqual(['Barony', 'Roam']);
+        expect(groups[1].projects.map((p) => p.title)).toEqual(['Viron']);
+    });
+
+    it('sorts categories alphabetically, case-insensitively', () => {
+        const groups = groupProjectsByCategory([
+            make('Barony', 'Games'),
+            make('env-lib-cpp', 'Libraries'),
+            make('Patchwork', 'assets'),
+        ]);
+        expect(groups.map((g) => g.category)).toEqual(['assets', 'Games', 'Libraries']);
+    });
+
+    it('sorts projects within a category alphabetically by title', () => {
+        const groups = groupProjectsByCategory([
+            make('Viron', 'Libraries'),
+            make('env-lib-cpp', 'Libraries'),
+        ]);
+        expect(groups[0].projects.map((p) => p.title)).toEqual(['env-lib-cpp', 'Viron']);
+    });
+
+    it('files projects with no category under "Other"', () => {
+        const groups = groupProjectsByCategory([make('Mystery')]);
+        expect(groups).toEqual([{ category: 'Other', projects: [make('Mystery')] }]);
+    });
+
+    it('does not mutate the input array', () => {
+        const input = [make('Beta', 'Games'), make('Alpha', 'Games')];
+        const snapshot = input.map((p) => p.title);
+        groupProjectsByCategory(input);
+        expect(input.map((p) => p.title)).toEqual(snapshot);
+    });
+
+    it('returns an empty array for no projects', () => {
+        expect(groupProjectsByCategory([])).toEqual([]);
     });
 });

--- a/__tests__/projects.test.tsx
+++ b/__tests__/projects.test.tsx
@@ -42,7 +42,10 @@ describe('Projects page', () => {
     });
 
     it('renders a card for every project in projects.json', () => {
-        const allCards = within(container).getAllByRole('link', { name: /github/i });
+        // Scoped to <main>, not the whole page — TopBar has its own "GitHub"
+        // nav link that would otherwise inflate this count by one.
+        const main = container.querySelector('main') as HTMLElement;
+        const allCards = within(main).getAllByRole('link', { name: /github/i });
         expect(allCards.length).toBe(projects.length);
     });
 

--- a/__tests__/projects.test.tsx
+++ b/__tests__/projects.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import ProjectsPage from '../pages/projects';
+import projectData from '../pages/data/projects.json';
+import packageJson from '../package.json';
+import { groupProjectsByCategory, type Project } from '../utils/projects';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/projects' }),
+}));
+
+const projects = projectData.projects as Project[];
+const categories = groupProjectsByCategory(projects);
+
+// Each card's only stable, class-free handle on which project it is showing is
+// its "GitHub" action, so read those in DOM order to recover the card order.
+const renderedTitlesInOrder = (section: HTMLElement): string[] => {
+    const byGithubLink = new Map(projects.map((p) => [p.githubLink, p.title]));
+    return within(section)
+        .getAllByRole('link', { name: /github/i })
+        .map((link) => byGithubLink.get(link.getAttribute('href') ?? '') ?? '<unknown>');
+};
+
+describe('Projects page', () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        ({ container } = render(<ProjectsPage/>));
+    });
+
+    it('renders a Projects heading', () => {
+        expect(screen.getByRole('heading', { level: 1, name: 'Projects' })).toBeInTheDocument();
+    });
+
+    it('renders a section heading for every category', () => {
+        for (const { category } of categories) {
+            expect(screen.getByRole('heading', { level: 2, name: category })).toBeInTheDocument();
+        }
+    });
+
+    it('renders a card for every project in projects.json', () => {
+        const allCards = within(container).getAllByRole('link', { name: /github/i });
+        expect(allCards.length).toBe(projects.length);
+    });
+
+    it('lists each category\'s projects alphabetically by title', () => {
+        for (const { category, projects: categoryProjects } of categories) {
+            const heading = screen.getByRole('heading', { level: 2, name: category });
+            const section = heading.closest('section') as HTMLElement;
+            expect(renderedTitlesInOrder(section)).toEqual(categoryProjects.map((p) => p.title));
+        }
+    });
+
+    it('shows the package.json version in the footer', () => {
+        expect(screen.getByText(`v${packageJson.version}`)).toBeInTheDocument();
+    });
+});

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -17,7 +17,17 @@ interface ProjectCardProps {
     // Optional link to a live/hosted version of the project; when set, the card
     // shows a "Visit Site" button as the primary action.
     websiteLink?: string;
+    // Optional maintenance status (e.g. "Active", "Maintenance"), shown as a
+    // colour-coded chip next to the technology chip.
+    status?: string;
 }
+
+// Colour for a status chip, keyed case-insensitively; unrecognized values fall
+// back to the default (grey) chip styling rather than guessing a colour.
+const STATUS_COLORS: Record<string, 'success' | 'warning'> = {
+    active: 'success',
+    maintenance: 'warning',
+};
 
 // A small, fixed palette of muted brand-ish colours. Each project gets a stable
 // colour derived from its title so cards have a bit of visual identity without
@@ -32,7 +42,7 @@ const colorForTitle = (title: string): string => {
     return AVATAR_COLORS[hash % AVATAR_COLORS.length];
 };
 
-const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink, technology, websiteLink}) => {
+const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink, technology, websiteLink, status}) => {
     return (
         <Card sx={projectCardStyle}>
             <CardContent sx={projectCardContentStyle}>
@@ -70,15 +80,25 @@ const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink
                 </Typography>
             </CardContent>
 
-            {technology ? (
-                <Box sx={{px: 2, pb: 1}}>
-                    <Chip
-                        size="small"
-                        variant="outlined"
-                        icon={<CodeIcon/>}
-                        label={technology}
-                    />
-                </Box>
+            {technology || status ? (
+                <Stack direction="row" spacing={1} sx={{px: 2, pb: 1}}>
+                    {technology ? (
+                        <Chip
+                            size="small"
+                            variant="outlined"
+                            icon={<CodeIcon/>}
+                            label={technology}
+                        />
+                    ) : null}
+                    {status ? (
+                        <Chip
+                            size="small"
+                            color={STATUS_COLORS[status.toLowerCase()]}
+                            variant={STATUS_COLORS[status.toLowerCase()] ? 'filled' : 'outlined'}
+                            label={status}
+                        />
+                    ) : null}
+                </Stack>
             ) : null}
 
             <CardActions sx={projectCardActionsStyle}>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -86,6 +86,7 @@ const TopBar: React.FC = () => {
 
                     <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
                         <NavButton href="/" active={isActiveNavLink(pathname, '/')}>Home</NavButton>
+                        <NavButton href="/projects" active={isActiveNavLink(pathname, '/projects')}>Projects</NavButton>
                         <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>
                         <NavButton href="/contact" active={isActiveNavLink(pathname, '/contact')}>Contact</NavButton>
                         <NavButton href="https://github.com/Preponderous-Software">GitHub</NavButton>

--- a/pages/data/projects.json
+++ b/pages/data/projects.json
@@ -5,7 +5,9 @@
       "title": "Apex-Ecosystem-Simulator",
       "description": "Observe the activity of a virtual environment containing entities that depend on each other as sources of energy.",
       "githubLink": "https://github.com/Preponderous-Software/Apex-Ecosystem-Simulator",
-      "technology": "Python"
+      "technology": "Python",
+      "category": "Simulations",
+      "status": "Active"
     },
     {
       "id": "barony",
@@ -13,21 +15,27 @@
       "description": "Command armies to capture villages and castles against an AI opponent.",
       "githubLink": "https://github.com/Preponderous-Software/barony",
       "technology": "Java",
-      "websiteLink": "https://barony.preponderous.org"
+      "websiteLink": "https://barony.preponderous.org",
+      "category": "Games",
+      "status": "Active"
     },
     {
       "id": "beyond-nations",
       "title": "Beyond-Nations",
       "description": "Sandbox Nation Simulation RPG",
       "githubLink": "https://github.com/Preponderous-Software/Beyond-Nations",
-      "technology": "C#"
+      "technology": "C#",
+      "category": "Games",
+      "status": "Active"
     },
     {
       "id": "env-lib-cpp",
       "title": "env-lib-cpp",
       "description": "Provides base classes for creating two-dimensional virtual worlds.",
       "githubLink": "https://github.com/Preponderous-Software/env-lib-cpp",
-      "technology": "C++"
+      "technology": "C++",
+      "category": "Libraries",
+      "status": "Maintenance"
     },
     {
       "id": "microbiome",
@@ -35,28 +43,36 @@
       "description": "Witness the activity of a virtual microbial community.",
       "githubLink": "https://github.com/Preponderous-Software/microbiome",
       "technology": "C++",
-      "websiteLink": "https://microbiome.preponderous.org"
+      "websiteLink": "https://microbiome.preponderous.org",
+      "category": "Simulations",
+      "status": "Active"
     },
     {
       "id": "ophidian",
       "title": "Ophidian",
       "description": "Control an ever-increasingly growing ophidian in a virtual environment.",
       "githubLink": "https://github.com/Preponderous-Software/Ophidian",
-      "technology": "Python"
+      "technology": "Python",
+      "category": "Games",
+      "status": "Active"
     },
     {
       "id": "patchwork",
       "title": "Patchwork",
       "description": "Patchwork is a lightweight tool for visualizing 2D environments, built with Python.",
       "githubLink": "https://github.com/Preponderous-Software/Patchwork",
-      "technology": "Python"
+      "technology": "Python",
+      "category": "Tools",
+      "status": "Maintenance"
     },
     {
       "id": "py-env-lib",
       "title": "py_env_lib",
       "description": "Provides base classes for creating two-dimensional virtual worlds.",
       "githubLink": "https://github.com/Preponderous-Software/py_env_lib",
-      "technology": "Python"
+      "technology": "Python",
+      "category": "Libraries",
+      "status": "Maintenance"
     },
     {
       "id": "roam",
@@ -64,14 +80,18 @@
       "description": "Explore a procedurally-generated 2D world and interact with your surroundings.",
       "githubLink": "https://github.com/Preponderous-Software/Roam",
       "technology": "Python",
-      "websiteLink": "https://roam.preponderous.org"
+      "websiteLink": "https://roam.preponderous.org",
+      "category": "Games",
+      "status": "Active"
     },
     {
       "id": "viron",
       "title": "Viron",
       "description": "Viron is a flexible simulation framework for building and managing 2D virtual environments.",
       "githubLink": "https://github.com/Preponderous-Software/Viron",
-      "technology": "Java"
+      "technology": "Java",
+      "category": "Libraries",
+      "status": "Active"
     },
     {
       "id": "daniel-stephenson",
@@ -79,7 +99,9 @@
       "description": "The personal portfolio site of Daniel McCoy Stephenson, the developer behind Preponderous Software.",
       "githubLink": "https://github.com/Stephenson-Software/danielstephenson-dot-dev",
       "technology": "TypeScript / Next.js",
-      "websiteLink": "https://danielstephenson.dev"
+      "websiteLink": "https://danielstephenson.dev",
+      "category": "Websites",
+      "status": "Active"
     },
     {
       "id": "dans-plugins-community",
@@ -87,7 +109,9 @@
       "description": "A Minecraft plugin community and showcase site, also run by the developer behind Preponderous Software.",
       "githubLink": "https://github.com/Dans-Plugins/dansplugins-dot-com",
       "technology": "TypeScript / Next.js",
-      "websiteLink": "https://dansplugins.com"
+      "websiteLink": "https://dansplugins.com",
+      "category": "Websites",
+      "status": "Active"
     }
   ]
 }

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -4,9 +4,8 @@ import React from 'react'
 import TopBar from '../components/TopBar'
 import BottomBar from '../components/BottomBar'
 import Seo from '../components/Seo'
-import Blurb from '../components/Blurb'
 import ProjectCard from '../components/ProjectCard'
-import {sortProjectsByTitle, type Project} from '../utils/projects'
+import {groupProjectsByCategory, type Project} from '../utils/projects'
 import {
     pageStyle,
     sectionHeaderStyle,
@@ -25,14 +24,10 @@ const projectData = require('./data/projects.json') as ProjectData
 // pull the displayed version from package.json so the footer stays in sync
 const version = require('../package.json').version
 
-const SectionDivider: React.FC = () => (
-    <Box sx={(theme) => sectionDividerStyle(theme)}/>
-)
-
-const ProjectsSection: React.FC<{projects: Project[]}> = ({projects}) => (
-    <Box id="projects" component="section" aria-labelledby="projects-heading" sx={projectsBoxStyle}>
-        <Typography id="projects-heading" variant="h3" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
-            Projects
+const CategorySection: React.FC<{category: string; projects: Project[]}> = ({category, projects}) => (
+    <Box component="section" aria-labelledby={`category-${category}`} sx={projectsBoxStyle}>
+        <Typography id={`category-${category}`} variant="h4" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+            {category}
         </Typography>
         <Grid container {...gridContainerStyle}>
             {projects.map((project) => (
@@ -51,20 +46,28 @@ const ProjectsSection: React.FC<{projects: Project[]}> = ({projects}) => (
     </Box>
 )
 
-const Home: NextPage = () => {
-    const projects = sortProjectsByTitle(projectData.projects)
+const ProjectsPage: NextPage = () => {
+    const categories = groupProjectsByCategory(projectData.projects)
     return (
         <Box sx={(theme) => pageStyle(theme)}>
-            <Seo path="/"/>
+            <Seo
+                title="Projects"
+                description="Every game, simulation, library, and tool Preponderous Software builds, grouped by category."
+                path="/projects"
+            />
             <TopBar/>
             <Container component="main" id="main" maxWidth="xl" sx={{py: 4, flexGrow: 1}}>
-                <Blurb/>
-                <SectionDivider/>
-                <ProjectsSection projects={projects}/>
+                <Typography variant="h3" component="h1" gutterBottom sx={{fontWeight: 700, letterSpacing: '-0.01em'}}>
+                    Projects
+                </Typography>
+                <Box sx={(theme) => sectionDividerStyle(theme)}/>
+                {categories.map(({category, projects}) => (
+                    <CategorySection key={category} category={category} projects={projects}/>
+                ))}
             </Container>
             <BottomBar version={version}/>
         </Box>
     )
 }
 
-export default Home
+export default ProjectsPage

--- a/utils/projects.ts
+++ b/utils/projects.ts
@@ -39,7 +39,7 @@ export const groupProjectsByCategory = (projects: Project[]): ProjectCategory[] 
         const category = project.category ?? 'Other';
         byCategory.set(category, [...(byCategory.get(category) ?? []), project]);
     }
-    return [...byCategory.entries()]
+    return Array.from(byCategory.entries())
         .sort(([a], [b]) => a.toLowerCase().localeCompare(b.toLowerCase()))
         .map(([category, categoryProjects]) => ({
             category,

--- a/utils/projects.ts
+++ b/utils/projects.ts
@@ -9,6 +9,19 @@ export interface Project {
     technology: string;
     // Optional link to a live/hosted version of the project.
     websiteLink?: string;
+    // Grouping used by the /projects page (e.g. "Games", "Simulations",
+    // "Libraries"). Optional so the home page's flat listing keeps working for
+    // entries that predate this field.
+    category?: string;
+    // Current maintenance state (e.g. "Active", "Maintenance"), shown on the
+    // /projects page as a status indicator. Optional for the same reason.
+    status?: string;
+}
+
+// A category and the projects filed under it.
+export interface ProjectCategory {
+    category: string;
+    projects: Project[];
 }
 
 // Sort projects alphabetically by title, case-insensitively. Returns a new
@@ -16,3 +29,20 @@ export interface Project {
 export const sortProjectsByTitle = (projects: Project[]): Project[] =>
     [...projects].sort((a, b) =>
         a.title.toLowerCase().localeCompare(b.title.toLowerCase()));
+
+// Group projects by their `category`, sorting the categories alphabetically
+// and the projects within each category by title. Projects with no category
+// are filed under "Other" so every entry is still shown on the /projects page.
+export const groupProjectsByCategory = (projects: Project[]): ProjectCategory[] => {
+    const byCategory = new Map<string, Project[]>();
+    for (const project of projects) {
+        const category = project.category ?? 'Other';
+        byCategory.set(category, [...(byCategory.get(category) ?? []), project]);
+    }
+    return [...byCategory.entries()]
+        .sort(([a], [b]) => a.toLowerCase().localeCompare(b.toLowerCase()))
+        .map(([category, categoryProjects]) => ({
+            category,
+            projects: sortProjectsByTitle(categoryProjects),
+        }));
+};


### PR DESCRIPTION
## Summary

- Add a `/projects` page listing every showcased project grouped by category (`Games`, `Simulations`, `Libraries`, `Tools`, `Websites`), linked from the top navigation bar.
- Add optional `category`/`status` fields to `pages/data/projects.json` entries (documented in `CONFIG.md`), plus a pure `groupProjectsByCategory` helper in `utils/projects.ts`.
- `ProjectCard` gains an optional colour-coded status chip (`Active` = green, `Maintenance` = amber), shown on both `/` and `/projects`.
- `status` values were derived from each project repo's actual `pushedAt` timestamp (via `gh repo view`) at the time of writing — recently active repos are `Active`, the rest `Maintenance` — rather than guessed.
- The issue's example categories ("Games, Assets, Templates") didn't match this catalog's actual project types, so categories were chosen to accurately reflect what's really being showcased instead (no "Assets" or "Templates" repos currently exist in the org).

Closes #17

## Note on issue #28 ("Add staging environment")

Left open and untouched this cycle — it asks for a Fly.io (or similar) deployment, which needs external hosting credentials/account access this agent doesn't have. Flagging for manual setup rather than attempting a partial/fabricated config.

## Note on local verification

This sandbox's WSL PATH only resolves a Windows-side `npm`/`node` (`/mnt/c/Program Files/nodejs/npm`), which fails on UNC paths during `npm ci`'s postinstall scripts — `npm run lint`/`npm test`/`npm run build` could not be run locally. Marking this **UNVERIFIED locally**; deferring to this PR's CI run (`.github/workflows/ci.yml`) on the actual head SHA as the external anchor before merge.

## Test plan

- [ ] CI (`npm ci` → `npm run lint` → `npm test` → `npm run build`) green on the PR head SHA
- [x] New unit tests for `groupProjectsByCategory` (grouping, alphabetical category/title ordering, "Other" fallback, non-mutation, empty input)
- [x] New/updated component tests for `ProjectCard`'s status chip and `TopBar`'s new "Projects" nav link (active-state + same-tab navigation)
- [x] New page test for `/projects` (heading, per-category sections, card count, per-category alphabetical ordering, footer version)

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
