### PR TITLE
Expand test coverage: 404/500 pages and BottomBar color-mode toggle

### DIFF
--- a/__tests__/404.test.tsx
+++ b/__tests__/404.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import NotFoundPage from '../pages/404';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/404' }),
+}));
+
+describe('404 page', () => {
+    beforeEach(() => {
+        render(<NotFoundPage/>);
+    });
+
+    it('renders the 404 code, title, and a not-found message', () => {
+        expect(screen.getByText('404')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 1, name: 'Page not found' })).toBeInTheDocument();
+        expect(
+            screen.getByText(/doesn't exist or may have moved/i)
+        ).toBeInTheDocument();
+    });
+
+    it('offers a way back to the home page', () => {
+        expect(screen.getByRole('link', { name: /back to home/i })).toHaveAttribute('href', '/');
+    });
+});

--- a/__tests__/500.test.tsx
+++ b/__tests__/500.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ServerErrorPage from '../pages/500';
+
+// The page renders TopBar, which reads the current route from next/router; there
+// is no router provider in a bare render, so stand one in.
+vi.mock('next/router', () => ({
+    useRouter: () => ({ pathname: '/500' }),
+}));
+
+describe('500 page', () => {
+    beforeEach(() => {
+        render(<ServerErrorPage/>);
+    });
+
+    it('renders the 500 code, title, and an unexpected-error message', () => {
+        expect(screen.getByText('500')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 1, name: 'Something went wrong' })).toBeInTheDocument();
+        expect(
+            screen.getByText(/unexpected error occurred/i)
+        ).toBeInTheDocument();
+    });
+
+    it('offers a way back to the home page', () => {
+        expect(screen.getByRole('link', { name: /back to home/i })).toHaveAttribute('href', '/');
+    });
+});

--- a/__tests__/BottomBar.test.tsx
+++ b/__tests__/BottomBar.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
 import BottomBar from '../components/BottomBar';
+import { ColorModeContext } from '../utils/ColorModeContext';
 import { formatCopyright, LICENSE_SHORT_NAME } from '../utils/copyright';
 
 describe('BottomBar', () => {
@@ -42,5 +44,31 @@ describe('BottomBar', () => {
 
     it('renders the color-mode toggle', () => {
         expect(screen.getByRole('checkbox', { name: /toggle dark mode/i })).toBeInTheDocument();
+    });
+
+    it('leaves the color-mode toggle unchecked in light mode', () => {
+        expect(screen.getByRole('checkbox', { name: /toggle dark mode/i })).not.toBeChecked();
+    });
+});
+
+describe('BottomBar color mode', () => {
+    it('checks the color-mode toggle in dark mode', () => {
+        render(
+            <ThemeProvider theme={createTheme({ palette: { mode: 'dark' } })}>
+                <BottomBar version="1.2.3"/>
+            </ThemeProvider>
+        );
+        expect(screen.getByRole('checkbox', { name: /toggle dark mode/i })).toBeChecked();
+    });
+
+    it('toggles the color mode when the switch is clicked', () => {
+        const toggleColorMode = vi.fn();
+        render(
+            <ColorModeContext.Provider value={{ toggleColorMode }}>
+                <BottomBar version="1.2.3"/>
+            </ColorModeContext.Provider>
+        );
+        fireEvent.click(screen.getByRole('checkbox', { name: /toggle dark mode/i }));
+        expect(toggleColorMode).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Stage B (unit-test expansion) cycle. A full documentation accuracy sweep (Stage A: README, CONFIG.md, USER_GUIDE.md, CONTRIBUTING.md, CHANGELOG.md against the actual source) found no drift, so this cycle instead closes a coverage gap found while comparing the source tree against `__tests__/`:

- `pages/404.tsx` and `pages/500.tsx` had no dedicated test files. Every other top-level page (`about`, `contact`, `legal`, `index`, `projects`) has one verifying its specific content; `ErrorPage.test.tsx` only exercises the shared component with generic props, not that these two pages wire it up with the right `code`/`title`/`message`. Added `__tests__/404.test.tsx` and `__tests__/500.test.tsx` mirroring the sibling page-test structure.
- `BottomBar` renders the same color-mode toggle as `TopBar`, wired to the same `ColorModeContext`/theme, but its test file was missing the checked-state (light/dark) and click-triggers-`toggleColorMode` assertions that `TopBar.test.tsx` already has. Added the matching cases to `__tests__/BottomBar.test.tsx`.

These are pure characterization tests — no production code changed.

No open issues were implemented this cycle: the only open issue (#28, "Add staging environment") requires provisioning an external Fly.io account, secrets, and DNS that I cannot do from this environment, so it's deferred (not attempted).

## Test plan

- [x] `git diff` reviewed — test-only changes, no production code touched
- [ ] CI (`npm ci && npm run lint && npm test && npm run build`) green on this PR — this sandbox's local Node/npm was non-functional (Windows npm shim on PATH, no Linux `node`), so verification relies on CI as the anchor; will confirm via `gh pr checks`

Closes: none (no tracking issue — gap found during test-expansion triage)

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
