### PR TITLE
feat: add Artificial-Consciousness-Simulation-Framework to projects list

### DIFF
--- a/pages/data/projects.json
+++ b/pages/data/projects.json
@@ -8,6 +8,13 @@
       "technology": "Python"
     },
     {
+      "id": "artificial-consciousness-simulation-framework",
+      "title": "Artificial-Consciousness-Simulation-Framework",
+      "description": "An autonomous AI agent with persistent identity, memory, and recursive self-reflection, grounded in consciousness science theory.",
+      "githubLink": "https://github.com/Preponderous-Software/artificial-consciousness-simulation-framework",
+      "technology": "Python"
+    },
+    {
       "id": "barony",
       "title": "Barony",
       "description": "Command armies to capture villages and castles against an AI opponent.",


### PR DESCRIPTION
## Summary

Adds the newly-public [Artificial-Consciousness-Simulation-Framework](https://github.com/Preponderous-Software/artificial-consciousness-simulation-framework) (v0.1.0, flipped public 2026-08-03) to `pages/data/projects.json`, in alphabetical order between Apex-Ecosystem-Simulator and Barony, matching `sortProjectsByTitle`'s ordering.

No `websiteLink` — the project has no hosted demo, matching most other entries (Apex-Ecosystem-Simulator, Beyond-Nations, env-lib-cpp, etc.).

## Testing

- `npm test` — 16/16 passed
- `npm run lint` — no warnings/errors
- `npm run build` — compiles successfully, all pages generate

---

_drafted by Claude on behalf of Daniel Stephenson_