### PR TITLE
fix: add category/status to the ACSF projects.json entry

### DIFF
--- a/pages/data/projects.json
+++ b/pages/data/projects.json
@@ -14,7 +14,9 @@
       "title": "Artificial-Consciousness-Simulation-Framework",
       "description": "An autonomous AI agent with persistent identity, memory, and recursive self-reflection, grounded in consciousness science theory.",
       "githubLink": "https://github.com/Preponderous-Software/artificial-consciousness-simulation-framework",
-      "technology": "Python"
+      "technology": "Python",
+      "category": "Simulations",
+      "status": "Active"
     },
     {
       "id": "barony",


### PR DESCRIPTION
## Summary

#80 added the Artificial-Consciousness-Simulation-Framework project entry, but a concurrent change landed on `main` first that added `category`/`status` fields to every other project (used by the new `/projects` page's grouping). The ACSF entry merged without them, so it would render under an "Other" catch-all category instead of alongside its peers.

Adds `"category": "Simulations"` (matching Apex-Ecosystem-Simulator, microbiome) and `"status": "Active"`.

## Testing

- `npm test` — 112/112 passed
- `npm run lint` — no warnings/errors
- `npm run build` — compiles successfully, all 7 pages generate

---

_drafted by Claude on behalf of Daniel Stephenson_