### PR TITLE
docs: fix stale LICENSE copyright year and CHANGELOG gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - `Seo` now emits a canonical `<link>`, `og:url`, and an `og:image`/`twitter:image` (with `twitter:card` upgraded to `summary_large_image`), documented in `CONFIG.md` (#65).
 - `/about` page covering the mission, values, and who runs Preponderous Software, and `/contact` page covering how to reach out (report a bug, or a project's own repository); both linked from the top navigation bar (#18, #19).
 - `/projects` page listing every showcased project grouped by category, plus an optional `status` chip (e.g. `Active`, `Maintenance`) on `ProjectCard`; both driven by new optional `category`/`status` fields on `pages/data/projects.json` entries, documented in `CONFIG.md` (#17).
+- Test coverage for the `404`/`500` error pages and `BottomBar`'s color-mode toggle (#79).
+- A project card for Artificial-Consciousness-Simulation-Framework, including its `category`/`status` fields (#80, #81).
 
 ### Changed
 
@@ -42,6 +44,7 @@ The site has been redesigned from Spring Boot + Thymeleaf to Next.js + React + M
 - Internal navigation (Home, brand wordmark, footer **Home**/**Legal**, error page "Back to home") now does a client-side route transition via `next/link` instead of a full document reload (#71).
 - The heading outline is now contiguous on every page: the **Projects** section, "Get involved", and each card title use the correct heading level, and each error page's `<h1>` is its human-readable title rather than the status code (#72).
 - Light-mode visitors no longer see a dark theme flash before hydration: a blocking script resolves the color mode before first paint and stamps it onto `<html data-color-mode>`, which `styles/globals.css` uses to paint the right background immediately (#73).
+- `LICENSE`'s copyright range is now open-ended (`2022–present`) instead of a fixed end year, so it no longer drifts behind the footer/`/legal` page's build-time-computed range (#84).
 
 ### Removed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 # 📄 Preponderous Non-Commercial License (Preponderous-NC)
 
 **Version 1.0**  
-**Copyright © 2022–2025 Daniel McCoy Stephenson. All rights reserved.**
+**Copyright © 2022–present Daniel McCoy Stephenson. All rights reserved.**
 
 > **Disclaimer:** *Preponderous Software is not a legal entity.*  
 > All rights to works published under this license are reserved by the copyright holder, **Daniel McCoy Stephenson**.


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `LICENSE`'s copyright line was changed from a fixed `2022–2025` end year to an open-ended `2022–present` range, so it no longer drifts behind the footer/`/legal` page's build-time-computed range (`utils/copyright.ts`).
- `CHANGELOG.md`'s `Unreleased > Added` section was updated with the two entries missing for the most recently merged PRs (#79, #80, #81), plus a `Fixed` entry documenting this PR's own LICENSE change.

## Why

A visitor comparing the site footer/`/legal` page's copyright range against the linked `LICENSE` file was shown two different end years for the same claim. Separately, two merged PRs' worth of user-visible change (new test coverage, a new showcased project) were left undocumented in the changelog.

## Test plan

- [x] Diff limited to `LICENSE` and `CHANGELOG.md`; no source files touched.
- [x] Grepped the repo for other hardcoded references to the stale `2022–2025` range; none found.
- [ ] CI (`npm ci` → lint → test → build) — this environment's local Node toolchain could not be exercised (`node`/`next` were unavailable in the sandbox), so this docs-only change is flagged **UNVERIFIED-not-applicable**: it touches no anchor-relevant (code/config) files, so the local anchor does not apply. GitHub Actions CI is the authoritative check for this PR.

Closes #84
Closes #85

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).