### PR TITLE
Honour the OS color preference when storage is blocked, and add robots.txt/sitemap.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- `public/robots.txt` and `public/sitemap.xml`, listing every indexable route so search engines can discover all of them, documented in `CONFIG.md` (#83).
+
+### Fixed
+
+- The color-mode bootstrap script no longer stamps `dark` on every visitor whose browser blocks site data: the stored-choice and `prefers-color-scheme` lookups are now guarded separately, so a light-preferring visitor with blocked storage gets a light page instead of MUI's light theme on a permanently dark background (#82).
+
 ## [0.2.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -70,6 +70,22 @@ mark ever changes, regenerate these with an SVG rasterizer (e.g. `sharp`,
 `resvg`, or ImageMagick); there is no rasterization step in this repo's own
 build.
 
+## Crawler Files
+
+Two static files under `public/` tell search engines what to crawl and index:
+
+| File | Purpose |
+|---|---|
+| `public/robots.txt` | Allows every crawler the whole site and points at the sitemap's absolute URL. |
+| `public/sitemap.xml` | Lists every indexable route (`/`, `/about`, `/contact`, `/legal`, `/projects`) as an absolute URL, matching the canonical links `components/Seo.tsx` emits. The shared `404`/`500` error pages are deliberately excluded — they have no canonical URL of their own. |
+
+Both are hand-written and hard-code the origin, because a file served straight
+out of `public/` is not templated at build time and so cannot read
+`NEXT_PUBLIC_SITE_URL`. `__tests__/sitemap.test.ts` is the guard against that
+duplication drifting: it fails if the sitemap's routes stop matching the pages
+under `pages/`, or if either file's origin stops matching `next.config.js`. When
+adding a page, add it to `public/sitemap.xml` in the same change.
+
 ## next.config.js
 
 Additional Next.js configuration lives in `next.config.js` in the project root. Refer to the [Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/introduction) for all available options.

--- a/__tests__/colorMode.test.ts
+++ b/__tests__/colorMode.test.ts
@@ -148,10 +148,34 @@ describe('COLOR_MODE_BOOTSTRAP_SCRIPT', () => {
         expect(document.documentElement.getAttribute('data-color-mode')).toBe('dark');
     });
 
-    it('falls back to dark instead of throwing when storage access is blocked', () => {
+    it('falls back to the OS preference instead of throwing when storage access is blocked', () => {
         stubThrowingStorage();
+        vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: true })));
 
         expect(() => runBootstrapScript()).not.toThrow();
+        expect(document.documentElement.getAttribute('data-color-mode')).toBe('dark');
+        expect(document.documentElement.style.colorScheme).toBe('dark');
+    });
+
+    // A light-preferring visitor with blocked site data used to be stamped
+    // 'dark' regardless, leaving the !important background rule in
+    // styles/globals.css dark under MUI's light theme.
+    it('stamps "light" for a light-preferring OS when storage access is blocked', () => {
+        stubThrowingStorage();
+        vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false })));
+
+        runBootstrapScript();
+
+        expect(document.documentElement.getAttribute('data-color-mode')).toBe('light');
+        expect(document.documentElement.style.colorScheme).toBe('light');
+    });
+
+    it('falls back to dark when storage is blocked and matchMedia is unavailable', () => {
+        stubThrowingStorage();
+        vi.stubGlobal('matchMedia', undefined);
+
+        runBootstrapScript();
+
         expect(document.documentElement.getAttribute('data-color-mode')).toBe('dark');
         expect(document.documentElement.style.colorScheme).toBe('dark');
     });

--- a/__tests__/sitemap.test.ts
+++ b/__tests__/sitemap.test.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import nextConfig from '../next.config.js';
+
+// public/sitemap.xml and public/robots.txt are hand-written static files, so
+// nothing in the build keeps them in step with the routes under pages/ or with
+// the canonical origin in next.config.js. These tests are that guard: adding a
+// page without listing it (or changing the site's origin in one place only)
+// fails here.
+const SITE_URL = nextConfig.env.NEXT_PUBLIC_SITE_URL;
+const publicFile = (name: string) =>
+    fs.readFileSync(path.join(__dirname, '..', 'public', name), 'utf8');
+
+// Pages that are real, indexable routes. _app/_document are framework
+// wrappers rather than routes, and the shared 404/500 error pages emit no
+// canonical URL (see components/Seo.tsx), so neither belongs in a sitemap.
+const NON_ROUTE_PAGES = ['_app', '_document', '404', '500'];
+
+const routePathsFromPagesDirectory = (): string[] =>
+    fs
+        .readdirSync(path.join(__dirname, '..', 'pages'))
+        .filter((entry) => entry.endsWith('.tsx'))
+        .map((entry) => entry.replace(/\.tsx$/, ''))
+        .filter((name) => !NON_ROUTE_PAGES.includes(name))
+        // The home page's canonical URL is the bare origin with a trailing
+        // slash, matching what <Seo path="/"/> emits on pages/index.tsx.
+        .map((name) => (name === 'index' ? '/' : `/${name}`));
+
+const sitemapLocations = (): string[] => {
+    const document = new DOMParser().parseFromString(
+        publicFile('sitemap.xml'),
+        'application/xml'
+    );
+    expect(document.getElementsByTagName('parsererror')).toHaveLength(0);
+    expect(document.documentElement.tagName).toBe('urlset');
+    expect(document.documentElement.getAttribute('xmlns')).toBe(
+        'http://www.sitemaps.org/schemas/sitemap/0.9'
+    );
+    return Array.from(document.getElementsByTagName('loc')).map(
+        (loc) => loc.textContent ?? ''
+    );
+};
+
+describe('public/sitemap.xml', () => {
+    it('lists every indexable route exactly once, with no others', () => {
+        const expected = routePathsFromPagesDirectory().map(
+            (route) => `${SITE_URL}${route}`
+        );
+
+        expect(sitemapLocations().sort()).toEqual(expected.sort());
+    });
+
+    it('omits the error pages, which have no canonical URL', () => {
+        const locations = sitemapLocations();
+
+        expect(locations).not.toContain(`${SITE_URL}/404`);
+        expect(locations).not.toContain(`${SITE_URL}/500`);
+    });
+});
+
+describe('public/robots.txt', () => {
+    it('allows every crawler to reach the whole site', () => {
+        const robots = publicFile('robots.txt');
+
+        expect(robots).toContain('User-agent: *');
+        expect(robots).toContain('Allow: /');
+        expect(robots).not.toContain('Disallow: /');
+    });
+
+    it('points crawlers at the sitemap on the configured origin', () => {
+        expect(publicFile('robots.txt')).toContain(
+            `Sitemap: ${SITE_URL}/sitemap.xml`
+        );
+    });
+});

--- a/__tests__/sitemap.test.ts
+++ b/__tests__/sitemap.test.ts
@@ -17,6 +17,9 @@ const publicFile = (name: string) =>
 // canonical URL (see components/Seo.tsx), so neither belongs in a sitemap.
 const NON_ROUTE_PAGES = ['_app', '_document', '404', '500'];
 
+// Every route the site has is a single file directly under pages/, so this
+// reads one level only. Nested route directories would need recursion here
+// before this guard covered them.
 const routePathsFromPagesDirectory = (): string[] =>
     fs
         .readdirSync(path.join(__dirname, '..', 'pages'))
@@ -28,16 +31,16 @@ const routePathsFromPagesDirectory = (): string[] =>
         .map((name) => (name === 'index' ? '/' : `/${name}`));
 
 const sitemapLocations = (): string[] => {
-    const document = new DOMParser().parseFromString(
+    const parsed = new DOMParser().parseFromString(
         publicFile('sitemap.xml'),
         'application/xml'
     );
-    expect(document.getElementsByTagName('parsererror')).toHaveLength(0);
-    expect(document.documentElement.tagName).toBe('urlset');
-    expect(document.documentElement.getAttribute('xmlns')).toBe(
+    expect(parsed.getElementsByTagName('parsererror')).toHaveLength(0);
+    expect(parsed.documentElement.tagName).toBe('urlset');
+    expect(parsed.documentElement.getAttribute('xmlns')).toBe(
         'http://www.sitemaps.org/schemas/sitemap/0.9'
     );
-    return Array.from(document.getElementsByTagName('loc')).map(
+    return Array.from(parsed.getElementsByTagName('loc')).map(
         (loc) => loc.textContent ?? ''
     );
 };
@@ -65,7 +68,12 @@ describe('public/robots.txt', () => {
 
         expect(robots).toContain('User-agent: *');
         expect(robots).toContain('Allow: /');
-        expect(robots).not.toContain('Disallow: /');
+        // Compared line by line rather than as a substring, so that a future
+        // narrow rule (`Disallow: /some-path`) does not read as a site-wide
+        // block; only a bare `Disallow: /` is one.
+        expect(robots.split('\n').map((line) => line.trim())).not.toContain(
+            'Disallow: /'
+        );
     });
 
     it('points crawlers at the sitemap on the configured origin', () => {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://preponderous.org/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Every route the site serves, so search engines can discover all of them
+  rather than only what they reach by following links. The URLs match the
+  canonical links components/Seo.tsx emits, origin included. The shared
+  404/500 error pages are deliberately absent: they have no canonical URL of
+  their own and should not be indexed.
+
+  This file is written by hand — adding a page under pages/ means adding it
+  here too. __tests__/sitemap.test.ts fails when the two disagree.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://preponderous.org/</loc>
+  </url>
+  <url>
+    <loc>https://preponderous.org/about</loc>
+  </url>
+  <url>
+    <loc>https://preponderous.org/contact</loc>
+  </url>
+  <url>
+    <loc>https://preponderous.org/legal</loc>
+  </url>
+  <url>
+    <loc>https://preponderous.org/projects</loc>
+  </url>
+</urlset>

--- a/utils/colorMode.ts
+++ b/utils/colorMode.ts
@@ -53,8 +53,15 @@ export const storeColorMode = (mode: ColorMode): void => {
 // [data-color-mode] rules in styles/globals.css can paint the right
 // background on the very first paint. pages/_app.tsx's own effect (which
 // does use resolveInitialColorMode) then resolves to the same value, so its
-// correction is visually a no-op. A thrown SecurityError (blocked site data)
-// falls back to 'dark', matching resolveInitialColorMode's own default.
-export const COLOR_MODE_BOOTSTRAP_SCRIPT = `(function(){try{var k=${JSON.stringify(
+// correction is visually a no-op.
+//
+// The two lookups are guarded separately so that one failing does not discard
+// the other's answer: a browser that blocks site data throws a SecurityError on
+// the storage read, and that visitor's prefers-color-scheme is still the best
+// available signal — the same fallback resolveInitialColorMode makes when
+// readStoredColorMode reports "nothing saved". Only when the media query is
+// unavailable too does the script settle on 'dark', matching the SSR-default
+// theme in pages/_app.tsx and the unqualified rule in styles/globals.css.
+export const COLOR_MODE_BOOTSTRAP_SCRIPT = `(function(){var m='dark';try{var p=window.matchMedia?window.matchMedia('(prefers-color-scheme: dark)').matches:true;m=p?'dark':'light';}catch(e){}try{var s=window.localStorage.getItem(${JSON.stringify(
     COLOR_MODE_STORAGE_KEY
-)};var s=window.localStorage.getItem(k);var p=window.matchMedia?window.matchMedia('(prefers-color-scheme: dark)').matches:true;var m=(s==='light'||s==='dark')?s:(p?'dark':'light');document.documentElement.setAttribute('data-color-mode',m);document.documentElement.style.colorScheme=m;}catch(e){document.documentElement.setAttribute('data-color-mode','dark');document.documentElement.style.colorScheme='dark';}})();`;
+)});if(s==='light'||s==='dark'){m=s;}}catch(e){}document.documentElement.setAttribute('data-color-mode',m);document.documentElement.style.colorScheme=m;})();`;


### PR DESCRIPTION
## Summary

- **#82 — color-mode bootstrap fallback.** `COLOR_MODE_BOOTSTRAP_SCRIPT` wrapped the `prefers-color-scheme` query and the `localStorage` read in a single `try`/`catch`, so a browser that blocks site data threw before the media query was consulted and the `catch` stamped `dark` unconditionally. A light-preferring visitor with blocked storage was therefore served MUI's light theme (React state resolves correctly via `resolveInitialColorMode`) on a background pinned dark by the `!important` rule in `styles/globals.css`, and nothing re-synced `<html data-color-mode>` after hydration. The two lookups are now guarded separately, so one failing no longer discards the other's answer; `dark` remains the result only when the media query is unavailable as well. The stale comment claiming the fallback "matches `resolveInitialColorMode`'s own default" has been corrected.
- **#83 — crawler files.** `public/robots.txt` and `public/sitemap.xml` have been added. The sitemap lists the five indexable routes (`/`, `/about`, `/contact`, `/legal`, `/projects`) as absolute URLs matching the canonical links `components/Seo.tsx` emits; the shared `404`/`500` pages are excluded, since they emit no canonical URL. Both files hard-code the origin, because a file served straight out of `public/` is not templated and cannot read `NEXT_PUBLIC_SITE_URL` — so `__tests__/sitemap.test.ts` guards the duplication instead, failing when the sitemap's routes stop matching the pages under `pages/` or when either file's origin stops matching `next.config.js`.
- `CONFIG.md` gained a "Crawler Files" section; `CHANGELOG.md` gained an `[Unreleased]` section covering both changes.

No `dansplugins-dot-com` counterpart was consulted for the crawler files — that repository's contents were not reachable from this session — so the conventional static `robots.txt`/`sitemap.xml` layout suggested in #83 was followed, with no new UI surface introduced by either change.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 19 files, 118 tests passing (three new bootstrap-script cases, four new crawler-file cases)
- [x] `npm run build` — compiled successfully, all 7 pages generated
- [x] Regression check for #82 verified empirically: with `utils/colorMode.ts` stashed, `stamps "light" for a light-preferring OS when storage access is blocked` FAILS (`expected 'dark' to be 'light'`); with the fix restored it PASSES.

## Deferred this cycle

- #28 (Add staging environment) — deferred because the work is a deployment-infrastructure change (provisioning a Fly.io-or-similar target and its credentials) rather than a repository change, and it cannot be completed or verified from an autonomous code-only cycle.

Closes #82
Closes #83

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_