### PR TITLE
Publish the top bar's links as a navigation landmark, and cover _document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The top bar's link group is now a named `navigation` landmark ("Primary"), matching the footer's, so assistive technology can list the site's primary navigation and the skip link has a landmark to skip past (#89).
 - The color-mode bootstrap script no longer stamps `dark` on every visitor whose browser blocks site data: the stored-choice and `prefers-color-scheme` lookups are now guarded separately, so a light-preferring visitor with blocked storage gets a light page instead of MUI's light theme on a permanently dark background (#82).
 
 ## [0.2.0-SNAPSHOT-8-8-2026] – 2026-08-08

--- a/__tests__/TopBar.test.tsx
+++ b/__tests__/TopBar.test.tsx
@@ -24,6 +24,14 @@ describe('TopBar', () => {
         expect(screen.getByRole('link', { name: 'Preponderous Software' })).toHaveAttribute('href', '/');
     });
 
+    it('labels the primary link group as navigation', () => {
+        render(<TopBar/>);
+        const nav = screen.getByRole('navigation', { name: /primary/i });
+        for (const name of ['Home', 'Projects', 'About', 'Contact', 'GitHub']) {
+            expect(nav).toContainElement(screen.getByRole('link', { name }));
+        }
+    });
+
     it('keeps internal nav links in the same tab', () => {
         render(<TopBar/>);
         for (const [name, href] of [['Home', '/'], ['Projects', '/projects'], ['About', '/about'], ['Contact', '/contact']] as const) {

--- a/__tests__/_document.test.tsx
+++ b/__tests__/_document.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import Document from '../pages/_document';
+import { COLOR_MODE_BOOTSTRAP_SCRIPT } from '../utils/colorMode';
+
+// next/document's primitives only work inside Next's own document renderer, so
+// they are replaced with plain containers that keep the props under test
+// observable. <html>/<head>/<body> cannot be nested inside jsdom's existing
+// document, hence the div stand-ins.
+vi.mock('next/document', () => ({
+    Html: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div data-testid="html" {...props}>{children}</div>
+    ),
+    Head: ({ children }: React.PropsWithChildren) => <div data-testid="head">{children}</div>,
+    Main: () => <div data-testid="main"/>,
+    NextScript: () => <div data-testid="next-script"/>,
+}));
+
+const renderDocument = () => render(<Document/>);
+
+describe('Document', () => {
+    it('declares the document language', () => {
+        const { getByTestId } = renderDocument();
+        expect(getByTestId('html')).toHaveAttribute('lang', 'en');
+    });
+
+    it('inlines the color-mode bootstrap script in the head', () => {
+        const { getByTestId } = renderDocument();
+        const script = getByTestId('head').querySelector('script');
+        expect(script).not.toBeNull();
+        expect(script?.innerHTML).toBe(COLOR_MODE_BOOTSTRAP_SCRIPT);
+    });
+
+    // The script stamps <html data-color-mode> before the body paints, which
+    // only holds while it stays render-blocking — an async/defer attribute
+    // would let the dark flash back in.
+    it('leaves the bootstrap script render-blocking', () => {
+        const { getByTestId } = renderDocument();
+        const script = getByTestId('head').querySelector('script') as HTMLScriptElement;
+        expect(script).not.toHaveAttribute('async');
+        expect(script).not.toHaveAttribute('defer');
+        expect(script).not.toHaveAttribute('src');
+    });
+
+    it('renders the bootstrap script before the page content', () => {
+        const { getByTestId } = renderDocument();
+        const head = getByTestId('head');
+        const main = getByTestId('main');
+        expect(head.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('links the icon assets that ship under public/', () => {
+        const { getByTestId } = renderDocument();
+        const hrefs = Array.from(getByTestId('head').querySelectorAll('link[rel*="icon"]'))
+            .map((link) => link.getAttribute('href'));
+        expect(hrefs).toEqual(
+            expect.arrayContaining(['/favicon.svg', '/favicon.png', '/apple-touch-icon.png'])
+        );
+    });
+
+    it('marks the SVG icon with its type so Safari can fall back to the PNG', () => {
+        const { getByTestId } = renderDocument();
+        const head = getByTestId('head');
+        expect(head.querySelector('link[href="/favicon.svg"]')).toHaveAttribute('type', 'image/svg+xml');
+        expect(head.querySelector('link[href="/favicon.png"]')).toHaveAttribute('sizes', '32x32');
+    });
+
+    it('preconnects to the Google Fonts origins the stylesheet is loaded from', () => {
+        const { getByTestId } = renderDocument();
+        const head = getByTestId('head');
+        const preconnects = Array.from(head.querySelectorAll('link[rel="preconnect"]'))
+            .map((link) => link.getAttribute('href'));
+        expect(preconnects).toEqual(
+            expect.arrayContaining(['https://fonts.googleapis.com', 'https://fonts.gstatic.com'])
+        );
+        expect(head.querySelector('link[rel="stylesheet"]'))
+            .toHaveAttribute('href', expect.stringContaining('fonts.googleapis.com'));
+    });
+
+    it('loads both brand font families', () => {
+        const { getByTestId } = renderDocument();
+        const stylesheet = getByTestId('head').querySelector('link[rel="stylesheet"]');
+        expect(stylesheet?.getAttribute('href')).toContain('Inter');
+        expect(stylesheet?.getAttribute('href')).toContain('Space+Grotesk');
+    });
+
+    it('renders the app content and the Next.js scripts', () => {
+        const { getByTestId } = renderDocument();
+        expect(getByTestId('main')).toBeInTheDocument();
+        expect(getByTestId('next-script')).toBeInTheDocument();
+    });
+});

--- a/__tests__/_document.test.tsx
+++ b/__tests__/_document.test.tsx
@@ -45,9 +45,9 @@ describe('Document', () => {
 
     it('renders the bootstrap script before the page content', () => {
         const { getByTestId } = renderDocument();
-        const head = getByTestId('head');
+        const script = getByTestId('head').querySelector('script') as HTMLScriptElement;
         const main = getByTestId('main');
-        expect(head.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(script.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
     it('links the icon assets that ship under public/', () => {

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -84,7 +84,11 @@ const TopBar: React.FC = () => {
                 <Box sx={(theme) => flexContainerStyle(theme, {flexWrap: 'wrap'})}>
                     <BrandName/>
 
-                    <Box sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
+                    {/* A named landmark, matching BottomBar's "Footer" nav, so
+                        assistive technology can list the site's primary
+                        navigation — and so the skip link in pages/_app.tsx has
+                        an actual landmark to skip past. */}
+                    <Box component="nav" aria-label="Primary" sx={(theme) => flexContainerStyle(theme, {gap: 1})}>
                         <NavButton href="/" active={isActiveNavLink(pathname, '/')}>Home</NavButton>
                         <NavButton href="/projects" active={isActiveNavLink(pathname, '/projects')}>Projects</NavButton>
                         <NavButton href="/about" active={isActiveNavLink(pathname, '/about')}>About</NavButton>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Html, Head, Main, NextScript} from 'next/document';
 import {COLOR_MODE_BOOTSTRAP_SCRIPT} from '../utils/colorMode';
 


### PR DESCRIPTION
## Summary

- The top bar's link group is now rendered as `<Box component="nav" aria-label="Primary">`, matching the landmark treatment `components/BottomBar.tsx` has carried since it was written. Before this change no primary navigation landmark was exposed to assistive technology, and the skip link in `pages/_app.tsx` — whose comment describes jumping "past the nav" — had no landmark to skip past.
- A characterization spec was added for `pages/_document.tsx`, the one behavior-bearing file under `pages/` with no mirror in `__tests__/`. What it pins down is the part that regresses silently: the color-mode bootstrap script must stay inline, render-blocking, and ahead of the page content (otherwise the dark flash fixed in #88 returns), the three icon links must keep pointing at the assets that ship under `public/` (Next 12 serves no icon of its own), and the document must declare `lang="en"`. `next/document`'s primitives only work inside Next's own renderer, so they are mocked as plain containers.
- No production code was changed under the `_document` spec — the existing behavior is asserted as-is.
- `CHANGELOG.md` records the landmark fix under Unreleased.

## Deferred this cycle

- #28 (add a staging environment) was not picked up: provisioning a Fly.io-style host requires an external account and credentials that are not available to an autonomous cycle, so the issue is human-gated rather than deprioritized.

## Test plan

- [ ] `npm run lint` — CI
- [ ] `npm test` — CI (no Node runtime is present in this session's sandbox, so the suite was **not** run locally; CI on this PR's head SHA is the anchor)
- [ ] `npm run build` — CI
- [ ] `__tests__/TopBar.test.tsx` — the primary link group is queryable by `getByRole('navigation', { name: /primary/i })` and contains all five links
- [ ] `__tests__/_document.test.tsx` — bootstrap script inline/render-blocking/ahead of content, icon links, font preconnects, `lang="en"`

Closes #89
Closes #90

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_