### PR TITLE
Name project card actions after their project, and slugify /projects category ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - `public/robots.txt` and `public/sitemap.xml`, listing every indexable route so search engines can discover all of them, documented in `CONFIG.md` (#83).
+- Test coverage for `ColorModeToggleSwitch`, the last component without a test file, including a guard that the `public/colormode/*.svg` icons its styles reference still exist (#94).
 
 ### Fixed
 
+- Each project card's **GitHub** and **Visit Site** buttons are now named after their project for assistive technology, so a page of cards no longer presents a dozen links called only "GitHub"; the **GitHub** button also carries the external-link icon the rest of the site uses for off-site links. The visible button text is unchanged (#92).
+- Category sections on `/projects` now derive their heading id from a slug of the category name, so a category containing a space (or punctuation) keeps its accessible name instead of pointing `aria-labelledby` at ids that do not exist (#93).
 - The top bar's link group is now a named `navigation` landmark ("Primary"), matching the footer's, so assistive technology can list the site's primary navigation and the skip link has a landmark to skip past (#89).
 - The color-mode bootstrap script no longer stamps `dark` on every visitor whose browser blocks site data: the stored-choice and `prefers-color-scheme` lookups are now guarded separately, so a light-preferring visitor with blocked storage gets a light page instead of MUI's light theme on a permanently dark background (#82).
 

--- a/__tests__/ColorModeToggleSwitch.test.tsx
+++ b/__tests__/ColorModeToggleSwitch.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ColorModeToggleSwitch } from '../components/ColorModeToggleSwitch';
+
+// TopBar and BottomBar drive the switch the same way — a `checked` prop taken
+// from the active theme and an `onChange` from ColorModeContext — so the
+// component is exercised here through that same contract.
+const renderSwitch = (props: { checked: boolean; onChange?: () => void }) =>
+    render(
+        <ColorModeToggleSwitch
+            checked={props.checked}
+            onChange={props.onChange}
+            inputProps={{ 'aria-label': 'Toggle dark mode' }}
+        />
+    );
+
+const toggle = () => screen.getByRole('checkbox', { name: /toggle dark mode/i });
+
+describe('ColorModeToggleSwitch', () => {
+    it('renders an accessibly-labelled control', () => {
+        renderSwitch({ checked: false });
+        expect(toggle()).toBeInTheDocument();
+    });
+
+    it('reflects the checked prop', () => {
+        const { unmount } = renderSwitch({ checked: true });
+        expect(toggle()).toBeChecked();
+        unmount();
+
+        renderSwitch({ checked: false });
+        expect(toggle()).not.toBeChecked();
+    });
+
+    it('calls onChange when the control is toggled', () => {
+        const onChange = vi.fn();
+        renderSwitch({ checked: false, onChange });
+        fireEvent.click(toggle());
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    // The visible switch is a styled wrapper around a real checkbox input, so
+    // keyboard operability comes from the input being focusable rather than
+    // from any handler of its own.
+    it('is reachable by keyboard focus', () => {
+        renderSwitch({ checked: false });
+        toggle().focus();
+        expect(toggle()).toHaveFocus();
+    });
+
+    // The sun/moon thumb is painted from two files under public/, referenced as
+    // bare strings in the styled rules, so nothing else in the build would
+    // notice if either asset were renamed or removed.
+    it('has the color-mode icon assets its styles reference', () => {
+        for (const asset of ['light.svg', 'dark.svg']) {
+            expect(existsSync(join(process.cwd(), 'public', 'colormode', asset))).toBe(true);
+        }
+    });
+});

--- a/__tests__/ProjectCard.test.tsx
+++ b/__tests__/ProjectCard.test.tsx
@@ -88,4 +88,39 @@ describe('ProjectCard', () => {
         // GitHub button still present alongside it
         expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
     });
+
+    it('names both actions after their project so they are distinguishable out of context', () => {
+        render(
+            <ProjectCard
+                title="Barony"
+                description="Command armies to capture villages and castles against an AI opponent."
+                githubLink="https://github.com/Preponderous-Software/barony"
+                technology="Java"
+                websiteLink="https://barony.preponderous.org"
+            />
+        );
+        expect(screen.getByRole('link', { name: 'Barony on GitHub' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Barony: Visit Site' })).toBeInTheDocument();
+    });
+
+    it('keeps the visible button text inside each accessible name', () => {
+        render(
+            <ProjectCard
+                title="Barony"
+                description="Command armies to capture villages and castles against an AI opponent."
+                githubLink="https://github.com/Preponderous-Software/barony"
+                technology="Java"
+                websiteLink="https://barony.preponderous.org"
+            />
+        );
+        // WCAG 2.5.3: speaking what is on screen has to match the link.
+        for (const [visibleText, accessibleName] of [
+            ['GitHub', 'Barony on GitHub'],
+            ['Visit Site', 'Barony: Visit Site'],
+        ] as const) {
+            const link = screen.getByRole('link', { name: accessibleName });
+            expect(link).toHaveTextContent(visibleText);
+            expect(accessibleName).toContain(visibleText);
+        }
+    });
 });

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -15,11 +15,13 @@ vi.mock('next/router', () => ({
 const projects = projectData.projects as Project[];
 
 // Each card's only stable, class-free handle on which project it is showing is
-// its "GitHub" action, so read those in DOM order to recover the card order.
+// its GitHub action ("<title> on GitHub"), so read those in DOM order to
+// recover the card order. Matched on the label's shape rather than an exact
+// name so this stays about ordering, not about how a card is labelled.
 const renderedTitlesInOrder = (section: HTMLElement): string[] => {
     const byGithubLink = new Map(projects.map((p) => [p.githubLink, p.title]));
     return within(section)
-        .getAllByRole('link', { name: 'GitHub' })
+        .getAllByRole('link', { name: /\bon GitHub$/ })
         .map((link) => byGithubLink.get(link.getAttribute('href') ?? '') ?? '<unknown>');
 };
 
@@ -54,7 +56,7 @@ describe('Home page', () => {
 
     it('links each card that has one to the project\'s own site', () => {
         const withSites = projects.filter((p) => p.websiteLink);
-        const visitLinks = within(projectsSection).getAllByRole('link', { name: 'Visit Site' });
+        const visitLinks = within(projectsSection).getAllByRole('link', { name: /: Visit Site$/ });
         expect(visitLinks.map((link) => link.getAttribute('href')).sort()).toEqual(
             withSites.map((p) => p.websiteLink).sort()
         );

--- a/__tests__/projects.test.ts
+++ b/__tests__/projects.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { groupProjectsByCategory, sortProjectsByTitle, type Project } from '../utils/projects';
+import { categoryHeadingId, groupProjectsByCategory, sortProjectsByTitle, type Project } from '../utils/projects';
 
 const make = (title: string, category?: string): Project => ({
     id: title.toLowerCase(),
@@ -71,5 +71,31 @@ describe('groupProjectsByCategory', () => {
 
     it('returns an empty array for no projects', () => {
         expect(groupProjectsByCategory([])).toEqual([]);
+    });
+});
+
+describe('categoryHeadingId', () => {
+    it('leaves a single-word category as a lowercase slug', () => {
+        expect(categoryHeadingId('Games')).toBe('category-games');
+    });
+
+    it('produces a whitespace-free id for a multi-word category', () => {
+        const id = categoryHeadingId('Developer Tools');
+        expect(id).toBe('category-developer-tools');
+        expect(id).not.toMatch(/\s/);
+    });
+
+    it('collapses punctuation and runs of separators', () => {
+        expect(categoryHeadingId('Games & Simulations')).toBe('category-games-simulations');
+        expect(categoryHeadingId('  Web   Apps  ')).toBe('category-web-apps');
+    });
+
+    it('never emits a leading or trailing separator', () => {
+        expect(categoryHeadingId('!Tools!')).toBe('category-tools');
+    });
+
+    it('falls back to a usable id when a category has nothing sluggable', () => {
+        expect(categoryHeadingId('!!!')).toBe('category-unnamed');
+        expect(categoryHeadingId('')).toBe('category-unnamed');
     });
 });

--- a/__tests__/projects.test.tsx
+++ b/__tests__/projects.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, within } from '@testing-library/react';
 import ProjectsPage from '../pages/projects';
 import projectData from '../pages/data/projects.json';
 import packageJson from '../package.json';
-import { groupProjectsByCategory, type Project } from '../utils/projects';
+import { categoryHeadingId, groupProjectsByCategory, type Project } from '../utils/projects';
 
 // The page renders TopBar, which reads the current route from next/router; there
 // is no router provider in a bare render, so stand one in.
@@ -54,6 +54,20 @@ describe('Projects page', () => {
             const heading = screen.getByRole('heading', { level: 2, name: category });
             const section = heading.closest('section') as HTMLElement;
             expect(renderedTitlesInOrder(section)).toEqual(categoryProjects.map((p) => p.title));
+        }
+    });
+
+    it('labels each category section with its own heading', () => {
+        for (const { category } of categories) {
+            const heading = screen.getByRole('heading', { level: 2, name: category });
+            const section = heading.closest('section') as HTMLElement;
+            const labelledBy = section.getAttribute('aria-labelledby');
+            // A single, whitespace-free id reference — aria-labelledby is a
+            // space-separated list, so a raw category name with a space in it
+            // would silently point at ids that do not exist.
+            expect(labelledBy).toBe(categoryHeadingId(category));
+            expect(labelledBy).not.toMatch(/\s/);
+            expect(section.querySelector(`#${labelledBy}`)).toBe(heading);
         }
     });
 

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -101,6 +101,15 @@ const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink
                 </Stack>
             ) : null}
 
+            {/* The visible button text stays short so every card reads the
+                same, but a page full of cards would otherwise expose a dozen
+                links named only "GitHub". aria-label prefixes the project each
+                action belongs to, so the links stay distinguishable when a
+                screen reader lists them away from their card, while still
+                containing the visible text verbatim so voice control can
+                activate them by what is on screen (WCAG 2.5.3). Both actions
+                also carry the site's external-link icon, matching TopBar,
+                BottomBar, and Blurb. */}
             <CardActions sx={projectCardActionsStyle}>
                 <Box sx={{flexGrow: 1}}/>
                 {websiteLink ? (
@@ -112,6 +121,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink
                         href={websiteLink}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`${title}: Visit Site`}
                     >
                         Visit Site
                     </Button>
@@ -120,10 +130,12 @@ const ProjectCard: React.FC<ProjectCardProps> = ({title, description, githubLink
                     variant={websiteLink ? 'outlined' : 'contained'}
                     size="small"
                     startIcon={<GitHubIcon/>}
+                    endIcon={<OpenInNewIcon fontSize="small"/>}
                     component={Link}
                     href={githubLink}
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label={`${title} on GitHub`}
                 >
                     GitHub
                 </Button>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -5,7 +5,7 @@ import TopBar from '../components/TopBar'
 import BottomBar from '../components/BottomBar'
 import Seo from '../components/Seo'
 import ProjectCard from '../components/ProjectCard'
-import {groupProjectsByCategory, type Project} from '../utils/projects'
+import {categoryHeadingId, groupProjectsByCategory, type Project} from '../utils/projects'
 import {
     pageStyle,
     sectionHeaderStyle,
@@ -24,27 +24,33 @@ const projectData = require('./data/projects.json') as ProjectData
 // pull the displayed version from package.json so the footer stays in sync
 const version = require('../package.json').version
 
-const CategorySection: React.FC<{category: string; projects: Project[]}> = ({category, projects}) => (
-    <Box component="section" aria-labelledby={`category-${category}`} sx={projectsBoxStyle}>
-        <Typography id={`category-${category}`} variant="h4" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
-            {category}
-        </Typography>
-        <Grid container {...gridContainerStyle}>
-            {projects.map((project) => (
-                <Grid item {...gridItemStyle} key={project.id}>
-                    <ProjectCard
-                        title={project.title}
-                        description={project.description}
-                        githubLink={project.githubLink}
-                        technology={project.technology}
-                        websiteLink={project.websiteLink}
-                        status={project.status}
-                    />
-                </Grid>
-            ))}
-        </Grid>
-    </Box>
-)
+const CategorySection: React.FC<{category: string; projects: Project[]}> = ({category, projects}) => {
+    // Slugified rather than interpolated raw: category names are free-form data
+    // and one containing a space would produce an invalid id and an
+    // aria-labelledby pointing at two ids that do not exist.
+    const headingId = categoryHeadingId(category)
+    return (
+        <Box component="section" aria-labelledby={headingId} sx={projectsBoxStyle}>
+            <Typography id={headingId} variant="h4" component="h2" gutterBottom sx={(theme) => sectionHeaderStyle(theme)}>
+                {category}
+            </Typography>
+            <Grid container {...gridContainerStyle}>
+                {projects.map((project) => (
+                    <Grid item {...gridItemStyle} key={project.id}>
+                        <ProjectCard
+                            title={project.title}
+                            description={project.description}
+                            githubLink={project.githubLink}
+                            technology={project.technology}
+                            websiteLink={project.websiteLink}
+                            status={project.status}
+                        />
+                    </Grid>
+                ))}
+            </Grid>
+        </Box>
+    )
+}
 
 const ProjectsPage: NextPage = () => {
     const categories = groupProjectsByCategory(projectData.projects)

--- a/utils/projects.ts
+++ b/utils/projects.ts
@@ -24,6 +24,15 @@ export interface ProjectCategory {
     projects: Project[];
 }
 
+// A DOM id for a category's heading, used by the /projects page to point each
+// section's aria-labelledby at its own heading. Category names come from
+// pages/data/projects.json and are free-form, so the raw value cannot be used:
+// an id must not contain whitespace, and aria-labelledby is a space-separated
+// list of id references — "category-Developer Tools" would resolve to two ids
+// that do not exist, leaving the section with no accessible name at all.
+export const categoryHeadingId = (category: string): string =>
+    `category-${category.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'unnamed'}`;
+
 // Sort projects alphabetically by title, case-insensitively. Returns a new
 // array (does not mutate the input) so callers can keep the source order.
 export const sortProjectsByTitle = (projects: Project[]): Project[] =>


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- **Project card actions are now named after their project.** Every card exposed a link whose entire accessible name was `GitHub` — thirteen of them on the home page — plus five named only `Visit Site`. An `aria-label` prefixed with the project title (`Barony on GitHub`, `Barony: Visit Site`) makes them distinguishable in the links list a screen reader user navigates by. Each label is kept as a superset of the visible text, so voice control can still activate a link by what is printed on it (WCAG 2.5.3). Visible button text is unchanged.
- **The GitHub button gained the external-link icon.** It opened in a new tab with no cue of any kind, while `TopBar`, `BottomBar`, `Blurb`, and the card's own **Visit Site** button all mark off-site links with `OpenInNewIcon`.
- **Category heading ids on `/projects` are slugified.** The raw category name was interpolated into the id, so a category containing a space would have yielded an invalid id and an `aria-labelledby` resolving to two ids that do not exist — the section would have lost its accessible name entirely. Category names are free-form data that `CONFIG.md` invites editing without code changes. Nothing is broken today: all five current categories happen to be single words.
- **`ColorModeToggleSwitch` has a test file.** It was the only component in `components/` without one. Beyond the `checked`/`onChange` contract that `TopBar` and `BottomBar` drive it by, the spec pins the two SVG assets its styled rules name as bare strings, which nothing else in the build would notice going missing.
- `CHANGELOG.md` records all three under `[Unreleased]`.

## Test plan

- [ ] `npm run lint` (CI)
- [ ] `npm test` (CI)
- [ ] `npm run build` (CI)
- [ ] `__tests__/ProjectCard.test.tsx` — both actions' project-qualified accessible names, and each name containing its visible text verbatim
- [ ] `__tests__/projects.test.ts` — `categoryHeadingId` over single-word, multi-word, punctuated, and empty category names
- [ ] `__tests__/projects.test.tsx` — every rendered category section's `aria-labelledby` is a single whitespace-free id that resolves to that section's own heading
- [ ] `__tests__/ColorModeToggleSwitch.test.tsx` — checked state, change handler, keyboard focus, and the presence of the color-mode icon assets

Note on coverage: the multi-word category case is proven at the `categoryHeadingId` unit level rather than by rendering the page, because `pages/projects.tsx` pulls its data through `require('./data/projects.json')` and mocking that module for a single case would be more fragile than the behaviour it verifies.

Closes #92
Closes #93
Closes #94

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).